### PR TITLE
fix: make githubbot configuration work better with aws

### DIFF
--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -10,20 +10,20 @@ import (
 )
 
 type Handler struct {
-	kbc      *kbchat.API
-	db       *DB
-	httpSrv  *HTTPSrv
-	httpAddr string
-	secret   string
+	kbc        *kbchat.API
+	db         *DB
+	httpSrv    *HTTPSrv
+	httpPrefix string
+	secret     string
 }
 
-func NewHandler(kbc *kbchat.API, db *DB, httpSrv *HTTPSrv, httpAddr string, secret string) *Handler {
+func NewHandler(kbc *kbchat.API, db *DB, httpSrv *HTTPSrv, httpPrefix string, secret string) *Handler {
 	return &Handler{
-		kbc:      kbc,
-		db:       db,
-		httpSrv:  httpSrv,
-		httpAddr: httpAddr,
-		secret:   secret,
+		kbc:        kbc,
+		db:         db,
+		httpSrv:    httpSrv,
+		httpPrefix: httpPrefix,
+		secret:     secret,
 	}
 }
 
@@ -110,7 +110,7 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool)
 			}
 
 			// setting up phase - send instructions
-			_, err = h.kbc.SendMessageByTlfName(msg.Sender.Username, formatSetupInstructions(args[0], h.httpAddr, h.secret))
+			_, err = h.kbc.SendMessageByTlfName(msg.Sender.Username, formatSetupInstructions(args[0], h.httpPrefix, h.secret))
 			if err != nil {
 				h.chatDebug(msg.ConvID, "Error sending message: %s", err)
 				return

--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -10,18 +10,16 @@ import (
 )
 
 type HTTPSrv struct {
-	kbc      *kbchat.API
-	db       *DB
-	httpAddr string
-	secret   string
+	kbc    *kbchat.API
+	db     *DB
+	secret string
 }
 
-func NewHTTPSrv(kbc *kbchat.API, db *DB, secret string, httpAddr string) *HTTPSrv {
+func NewHTTPSrv(kbc *kbchat.API, db *DB, secret string) *HTTPSrv {
 	return &HTTPSrv{
-		kbc:      kbc,
-		db:       db,
-		secret:   secret,
-		httpAddr: httpAddr,
+		kbc:    kbc,
+		db:     db,
+		secret: secret,
 	}
 }
 
@@ -116,5 +114,5 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 func (h *HTTPSrv) Listen() error {
 	http.HandleFunc("/githubbot", h.handleHealthCheck)
 	http.HandleFunc("/githubbot/webhook", h.handleWebhook)
-	return http.ListenAndServe(h.httpAddr, nil)
+	return http.ListenAndServe(":8080", nil)
 }

--- a/githubbot/main.go
+++ b/githubbot/main.go
@@ -19,7 +19,7 @@ type Options struct {
 	KeybaseLocation string
 	Home            string
 	Announcement    string
-	HTTPAddr        string
+	HTTPPrefix      string
 	DSN             string
 	Secret          string
 }
@@ -188,8 +188,8 @@ func (s *BotServer) Start() (err error) {
 		return err
 	}
 
-	httpSrv := githubbot.NewHTTPSrv(s.kbc, db, secret, s.opts.HTTPAddr)
-	handler := githubbot.NewHandler(s.kbc, db, httpSrv, s.opts.HTTPAddr, secret)
+	httpSrv := githubbot.NewHTTPSrv(s.kbc, db, secret)
+	handler := githubbot.NewHandler(s.kbc, db, httpSrv, s.opts.HTTPPrefix, secret)
 	var eg errgroup.Group
 	eg.Go(handler.Listen)
 	eg.Go(httpSrv.Listen)
@@ -213,7 +213,7 @@ func mainInner() int {
 	flag.StringVar(&opts.Announcement, "announcement", os.Getenv("BOT_ANNOUNCEMENT"),
 		"Where to announce we are running")
 	flag.StringVar(&opts.DSN, "dsn", os.Getenv("BOT_DSN"), "Bot database DSN")
-	flag.StringVar(&opts.HTTPAddr, "http-addr", os.Getenv("BOT_HTTP_ADDR"), "address of bots HTTP server for oauth requests")
+	flag.StringVar(&opts.HTTPPrefix, "http-prefix", os.Getenv("BOT_HTTP_PREFIX"), "address of bots HTTP server for webhooks")
 	flag.StringVar(&opts.Secret, "secret", os.Getenv("BOT_WEBHOOK_SECRET"), "Webhook secret")
 	flag.Parse()
 	if len(opts.DSN) == 0 {


### PR DESCRIPTION
replaces httpaddr with httpprefix to match up with pollbot better and make the aws setup a little nicer