### PR TITLE
Parse all CI events, use OAuth client in webhook handler

### DIFF
--- a/githubbot/db.sql
+++ b/githubbot/db.sql
@@ -11,7 +11,9 @@ CREATE TABLE `subscriptions` (
   `conv_id` char(64) NOT NULL,
   `repo` varchar(128) NOT NULL,
   `branch` varchar(128) NOT NULL,
-  `hook_id` bigint(20) NOT NULL
+  `hook_id` bigint(20) NOT NULL,
+  `oauth_identifier` varchar(128) NOT NULL,
+  UNIQUE KEY unique_subscription (`conv_id`, `repo`, `branch`) 
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `user_prefs` (

--- a/githubbot/githubbot/db.go
+++ b/githubbot/githubbot/db.go
@@ -53,13 +53,13 @@ func (d *DB) DeleteSubscriptionsForRepo(convID chat1.ConvIDStr, repo string) err
 	})
 }
 
-func (d *DB) GetSubscribedConvs(repo string, branch string) (res []chat1.ConvIDStr, err error) {
+func (d *DB) GetConvsFromRepo(repo string) (res []chat1.ConvIDStr, err error) {
 	rows, err := d.DB.Query(`
 		SELECT conv_id
 		FROM subscriptions
-		WHERE (repo = ? AND branch = ?)
+		WHERE repo = ?
 		GROUP BY conv_id
-	`, repo, branch)
+	`, repo)
 	if err != nil {
 		return res, err
 	}
@@ -72,6 +72,26 @@ func (d *DB) GetSubscribedConvs(repo string, branch string) (res []chat1.ConvIDS
 	}
 	return res, nil
 }
+
+// func (d *DB) GetSubscribedConvs(repo string, branch string) (res []chat1.ConvIDStr, err error) {
+// 	rows, err := d.DB.Query(`
+// 		SELECT conv_id
+// 		FROM subscriptions
+// 		WHERE (repo = ? AND branch = ?)
+// 		GROUP BY conv_id
+// 	`, repo, branch)
+// 	if err != nil {
+// 		return res, err
+// 	}
+// 	for rows.Next() {
+// 		var convID chat1.ConvIDStr
+// 		if err := rows.Scan(&convID); err != nil {
+// 			return res, err
+// 		}
+// 		res = append(res, convID)
+// 	}
+// 	return res, nil
+// }
 
 func (d *DB) GetSubscriptionExists(convID chat1.ConvIDStr, repo string, branch string) (exists bool, err error) {
 	row := d.DB.QueryRow(`

--- a/githubbot/githubbot/db.go
+++ b/githubbot/githubbot/db.go
@@ -3,8 +3,6 @@ package githubbot
 import (
 	"database/sql"
 
-	"github.com/go-sql-driver/mysql"
-
 	"github.com/keybase/go-keybase-chat-bot/kbchat/types/chat1"
 	"github.com/keybase/managed-bots/base"
 	"golang.org/x/oauth2"
@@ -29,20 +27,9 @@ func (d *DB) CreateSubscription(convID chat1.ConvIDStr, repo string, branch stri
 			(conv_id, repo, branch, hook_id, oauth_identifier)
 			VALUES
 			(?, ?, ?, ?, ?)
+			ON DUPLICATE KEY UPDATE
+			hook_id=VALUES(hook_id)
 		`, convID, repo, branch, hookID, oauthIdentifier)
-		if txErr, ok := err.(*mysql.MySQLError); ok {
-			// if dupe key, update hook id
-			if txErr.Number == 1062 {
-				return d.RunTxn(func(tx *sql.Tx) error {
-					_, err := tx.Exec(`
-					UPDATE subscriptions
-					SET hook_id = ?
-					WHERE (conv_id = ? AND repo = ? AND branch = ?)
-				`, hookID, convID, repo, branch)
-					return err
-				})
-			}
-		}
 		return err
 	})
 }

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -281,11 +281,14 @@ func (h *Handler) handleMentionPref(cmd string, msg chat1.MsgSummary) (err error
 }
 
 func (h *Handler) handleAuth(msg chat1.MsgSummary, client *github.Client) (err error) {
-	if client != nil {
-		_, err = h.kbc.SendMessageByConvID(msg.ConvID, "You're authenticated with GitHub!")
-		if err != nil {
-			err = fmt.Errorf("error sending message: %s", err)
-		}
+	if client == nil {
+		err = fmt.Errorf("auth check called with empty client")
+		return err
+	}
+
+	_, err = h.kbc.SendMessageByConvID(msg.ConvID, "You're authenticated with GitHub!")
+	if err != nil {
+		err = fmt.Errorf("error sending message: %s", err)
 	}
 	return err
 }

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -282,8 +282,7 @@ func (h *Handler) handleMentionPref(cmd string, msg chat1.MsgSummary) (err error
 
 func (h *Handler) handleAuth(msg chat1.MsgSummary, client *github.Client) (err error) {
 	if client == nil {
-		err = fmt.Errorf("auth check called with empty client")
-		return err
+		return fmt.Errorf("auth check called with empty client")
 	}
 
 	_, err = h.kbc.SendMessageByConvID(msg.ConvID, "You're authenticated with GitHub!")

--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -73,7 +73,7 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 
 	if repo != "" {
 		signature := r.Header.Get("X-Hub-Signature")
-		convs, err := h.db.GetConvsFromRepo(repo)
+		convs, err := h.db.GetConvIDsFromRepo(repo)
 		if err != nil {
 			h.Debug("Error getting subscriptions for repo: %s", err)
 			return
@@ -85,12 +85,7 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 				h.Debug("Error validating payload signature for conversation %s: %s", convID, err)
 				continue
 			}
-			conv, err := h.kbc.GetConversation(convID)
-			if err != nil {
-				h.Debug("could not get conversation: %s\n", err)
-				return
-			}
-			token, err := h.db.GetToken(conv.Channel.Name)
+			token, err := h.db.GetTokenFromConvID(convID)
 			if err != nil {
 				h.Debug("could not get token for convID: %s\n", err)
 				return

--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -1,6 +1,7 @@
 package githubbot
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 type HTTPSrv struct {
 	*base.OAuthHTTPSrv
 
+	config  *oauth2.Config
 	kbc     *kbchat.API
 	db      *DB
 	handler *Handler
@@ -41,7 +43,7 @@ func (h *HTTPSrv) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
 func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	payload, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		h.Debug("Error reading payload: %s", err)
+		h.Debug("Error reading payload: %s\n", err)
 		return
 	}
 	defer r.Body.Close()
@@ -52,61 +54,26 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var message string
+	type genericPayload interface {
+		GetRepo() *github.Repository
+	}
 	var repo string
-	branch := "master"
 	switch event := event.(type) {
-	case *github.IssuesEvent:
-		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
-		message = formatIssueMsg(event, author.String())
-		repo = event.GetRepo().GetFullName()
-		branch, err = getDefaultBranch(repo, github.NewClient(nil))
-		if err != nil {
-			h.Debug("error getting default branch: %s", err)
-			return
-		}
-	case *github.PullRequestEvent:
-		var author username
-		if event.GetPullRequest().GetMerged() {
-			author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetPullRequest().GetMergedBy().GetLogin())
-		} else {
-			author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
-		}
-		message = formatPRMsg(event, author.String())
-		repo = event.GetRepo().GetFullName()
-
-		branch, err = getDefaultBranch(repo, github.NewClient(nil))
-		if err != nil {
-			h.Debug("error getting default branch: %s", err)
-			return
-		}
 	case *github.PushEvent:
-		if len(event.Commits) == 0 {
-			break
-		}
-		message = formatPushMsg(event, event.GetSender().GetLogin())
+		// PushEvent.GetRepo() returns *github.PushEventRepository instead of *github.Repository, so we handle it separately
 		repo = event.GetRepo().GetFullName()
-		branch = refToName(event.GetRef())
-	case *github.CheckSuiteEvent:
-		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
-		repo = event.GetRepo().GetFullName()
-		if len(event.GetCheckSuite().PullRequests) == 0 {
-			// this is a branch test, not associated with a PR
-			branch = event.GetCheckSuite().GetHeadBranch()
+	default:
+		if evt, ok := event.(genericPayload); ok {
+			repo = evt.GetRepo().GetFullName()
 		} else {
-			branch, err = getDefaultBranch(repo, github.NewClient(nil))
-		}
-		message = formatCheckSuiteMsg(event, author.String())
-		if err != nil {
-			h.Debug("error getting default branch: %s", err)
+			h.Debug("could not get repo from webhook, webhook type: %s\n", github.WebHookType(r))
 			return
 		}
 	}
 
-	if message != "" && repo != "" {
+	if repo != "" {
 		signature := r.Header.Get("X-Hub-Signature")
-
-		convs, err := h.db.GetSubscribedConvs(repo, branch)
+		convs, err := h.db.GetConvsFromRepo(repo)
 		if err != nil {
 			h.Debug("Error getting subscriptions for repo: %s", err)
 			return
@@ -118,11 +85,89 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 				h.Debug("Error validating payload signature for conversation %s: %s", convID, err)
 				continue
 			}
-			_, err = h.kbc.SendMessageByConvID(convID, message)
+			conv, err := h.kbc.GetConversation(convID)
 			if err != nil {
-				h.Debug("Error sending message: %s", err)
+				h.Debug("could not get conversation: %s\n", err)
 				return
+			}
+			token, err := h.db.GetToken(conv.Channel.Name)
+			if err != nil {
+				h.Debug("could not get token for convID: %s\n", err)
+				return
+			}
+			client := github.NewClient(h.config.Client(context.TODO(), token))
+			message, branch := h.formatMessage(event, repo, client)
+			if message != "" {
+				subscriptionExists, err := h.db.GetSubscriptionExists(convID, repo, branch)
+				if err != nil {
+					h.Debug("could not get subscription: %s\n", err)
+					return
+				}
+
+				if subscriptionExists {
+					_, err = h.kbc.SendMessageByConvID(convID, message)
+					if err != nil {
+						h.Debug("Error sending message: %s", err)
+						return
+					}
+				}
 			}
 		}
 	}
+}
+
+func (h *HTTPSrv) formatMessage(event interface{}, repo string, client *github.Client) (message string, branch string) {
+	branch, err := getDefaultBranch(repo, client)
+	if err != nil {
+		h.Debug("formatMessage: error getting default branch: %s", err)
+		return "", ""
+	}
+	switch event := event.(type) {
+	case *github.IssuesEvent:
+		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
+		message = formatIssueMsg(event, author.String())
+	case *github.PullRequestEvent:
+		var author username
+		if event.GetPullRequest().GetMerged() {
+			author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetPullRequest().GetMergedBy().GetLogin())
+		} else {
+			author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
+		}
+		message = formatPRMsg(event, author.String())
+	case *github.PushEvent:
+		if len(event.Commits) == 0 {
+			break
+		}
+		message = formatPushMsg(event, "*"+event.GetSender().GetLogin()+"*")
+		branch = refToName(event.GetRef())
+	case *github.CheckRunEvent:
+		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
+		if len(event.GetCheckRun().PullRequests) == 0 {
+			// this is a branch test, not associated with a PR
+			branch = event.GetCheckRun().GetCheckSuite().GetHeadBranch()
+		}
+		// if we're parsing a pr, use the default branch
+		message = formatCheckRunMessage(event, author.String())
+	case *github.StatusEvent:
+		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
+		pullRequests, _, err := client.PullRequests.ListPullRequestsWithCommit(
+			context.TODO(),
+			event.GetRepo().GetOwner().GetLogin(),
+			event.GetRepo().GetName(),
+			event.GetSHA(),
+			&github.PullRequestListOptions{
+				State: "open",
+			},
+		)
+		if err != nil {
+			h.Debug("error getting pull requests from commit: %s", err)
+		}
+		if len(pullRequests) == 0 && len(event.Branches) >= 1 {
+			// this is a branch test, not associated with a PR
+			branch = event.Branches[0].GetName()
+		}
+		message = formatStatusMessage(event, pullRequests, author.String())
+
+	}
+	return message, branch
 }

--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -133,7 +133,7 @@ func (h *HTTPSrv) formatMessage(event interface{}, repo string, client *github.C
 		if len(event.Commits) == 0 {
 			break
 		}
-		message = formatPushMsg(event, "*"+event.GetSender().GetLogin()+"*")
+		message = formatPushMsg(event, fmt.Sprintf("*%s*", event.GetSender().GetLogin()))
 		branch = refToName(event.GetRef())
 	case *github.CheckRunEvent:
 		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())

--- a/githubbot/githubbot/util.go
+++ b/githubbot/githubbot/util.go
@@ -148,7 +148,7 @@ func formatCheckRunMessage(evt *github.CheckRunEvent, username string) (res stri
 	return res
 }
 
-func formatStatusMessage(evt *github.StatusEvent, pullRequests []*github.PullRequest, username string) (res string, err error) {
+func formatStatusMessage(evt *github.StatusEvent, pullRequests []*github.PullRequest, username string) (res string) {
 	state := evt.GetState()
 	repo := evt.GetRepo().GetName()
 	isPullRequest := len(pullRequests) > 0

--- a/githubbot/githubbot/util.go
+++ b/githubbot/githubbot/util.go
@@ -97,38 +97,100 @@ func formatPRMsg(evt *github.PullRequestEvent, username string) (res string) {
 	return res
 }
 
-func formatCheckSuiteMsg(evt *github.CheckSuiteEvent, username string) (res string) {
+func formatCheckRunMessage(evt *github.CheckRunEvent, username string) (res string) {
 	action := evt.Action
 	if *action == "completed" {
-		suite := evt.GetCheckSuite()
+		run := evt.GetCheckRun()
 		repo := evt.GetRepo().GetName()
-		isPullRequest := len(suite.PullRequests) > 0
-		switch suite.GetConclusion() {
+		isPullRequest := len(run.PullRequests) > 0
+		var testName string
+		if run.GetName() != "" {
+			testName = fmt.Sprintf("*%s*", run.GetName())
+		} else {
+			testName = "Test"
+		}
+		switch run.GetConclusion() {
 		case "success":
 			if !isPullRequest {
-				res = fmt.Sprintf(":white_check_mark: Tests passed for %s/%s.", repo, suite.GetHeadBranch())
+				res = fmt.Sprintf(":white_check_mark: %s passed for %s/%s.", testName, repo, run.GetCheckSuite().GetHeadBranch())
 			} else {
-				pr := suite.PullRequests[0]
-				res = fmt.Sprintf(":white_check_mark: All tests passed for pull request #%d on %s.\n%s/pull/%d", pr.GetNumber(), repo, evt.GetRepo().GetHTMLURL(), pr.GetNumber())
+				pr := run.PullRequests[0]
+				res = fmt.Sprintf(":white_check_mark: %s passed for pull request #%d on %s.\n%s/pull/%d", testName, pr.GetNumber(), repo, evt.GetRepo().GetHTMLURL(), pr.GetNumber())
 			}
 		case "failure", "timed_out", "action_required":
-			if !isPullRequest {
-				res = fmt.Sprintf(":x: Tests failed for %s/%s.", repo, suite.GetHeadBranch())
+			urlSplit := strings.Split(run.GetHTMLURL(), "://")
+			var targetURL string
+			if len(urlSplit) != 2 {
+				// if the CI target URL isn't formatted as expected, just skip it
+				targetURL = ""
 			} else {
-				pr := suite.PullRequests[0]
-				res = fmt.Sprintf(":x: Tests failed for pull request #%d on %s.\n%s/pull/%d", pr.GetNumber(), repo, evt.GetRepo().GetHTMLURL(), pr.GetNumber())
+				targetURL = urlSplit[1]
+			}
+
+			if !isPullRequest {
+				res = fmt.Sprintf(":x: %s failed for %s/%s.\n%s", testName, repo, run.GetCheckSuite().GetHeadBranch(), targetURL)
+			} else {
+				pr := run.PullRequests[0]
+				res = fmt.Sprintf(":x: %s failed for pull request #%d on %s.\n%s", testName, pr.GetNumber(), repo, targetURL)
 			}
 		case "cancelled":
 			if !isPullRequest {
-				res = fmt.Sprintf(":warning: Tests cancelled for %s/%s.", repo, suite.GetHeadBranch())
+				res = fmt.Sprintf(":warning: %s cancelled for %s/%s.", testName, repo, run.GetCheckSuite().GetHeadBranch())
 			} else {
-				pr := suite.PullRequests[0]
-				res = fmt.Sprintf(":warning: Tests cancelled for pull request #%d on %s.\n%s/pull/%d", pr.GetNumber(), repo, evt.GetRepo().GetHTMLURL(), pr.GetNumber())
+				pr := run.PullRequests[0]
+				res = fmt.Sprintf(":warning: %s cancelled for pull request #%d on %s.\n%s/pull/%d", testName, pr.GetNumber(), repo, evt.GetRepo().GetHTMLURL(), pr.GetNumber())
 			}
 		}
 		if strings.HasPrefix(username, "@") && isPullRequest && res != "" {
 			res = res + "\n" + username
 		}
+	}
+	return res
+}
+
+func formatStatusMessage(evt *github.StatusEvent, pullRequests []*github.PullRequest, username string) (res string) {
+	state := evt.GetState()
+	repo := evt.GetRepo().GetName()
+	isPullRequest := len(pullRequests) > 0
+	var branch string
+	if len(evt.Branches) < 1 {
+		return
+	}
+	branch = evt.Branches[0].GetName()
+	var testName string
+	if evt.GetContext() != "" {
+		testName = fmt.Sprintf("*%s*", evt.GetContext())
+	} else {
+		testName = "Test"
+	}
+	switch state {
+	case "success":
+		if !isPullRequest {
+			res = fmt.Sprintf(":white_check_mark: %s passed for %s/%s.", testName, repo, branch)
+		} else {
+			pr := pullRequests[0]
+			res = fmt.Sprintf(":white_check_mark: %s passed for pull request #%d on %s.\n%s/pull/%d", testName, pr.GetNumber(), repo, evt.GetRepo().GetHTMLURL(), pr.GetNumber())
+		}
+	case "failure", "error":
+		var targetURL string
+		urlSplit := strings.Split(evt.GetTargetURL(), "://")
+		if len(urlSplit) != 2 {
+			// if the CI target URL isn't formatted as expected, just skip it
+			targetURL = ""
+		} else {
+			targetURL = urlSplit[1]
+		}
+
+		if !isPullRequest {
+			res = fmt.Sprintf(":x: %s failed for %s/%s.\n%s", testName, repo, branch, targetURL)
+		} else {
+			pr := pullRequests[0]
+
+			res = fmt.Sprintf(":x: %s failed for pull request #%d on %s.\n%s", testName, pr.GetNumber(), repo, targetURL)
+		}
+	}
+	if strings.HasPrefix(username, "@") && isPullRequest && res != "" {
+		res = res + "\n" + username
 	}
 	return res
 }
@@ -144,11 +206,11 @@ func getDefaultBranch(repo string, client *github.Client) (branch string, err er
 	}
 
 	repoObject, res, err := client.Repositories.Get(context.TODO(), args[0], args[1])
-	if res.StatusCode == http.StatusNotFound {
-		return "master", nil
-	}
 	if err != nil {
 		return "", err
+	}
+	if res.StatusCode == http.StatusNotFound {
+		return "master", nil
 	}
 
 	return repoObject.GetDefaultBranch(), nil
@@ -166,7 +228,7 @@ func (u username) String() string {
 		return "@" + *u.keybaseUsername
 	}
 
-	return u.githubUsername
+	return fmt.Sprintf("*%s*", u.githubUsername)
 }
 
 type keybaseID struct {

--- a/githubbot/githubbot/util.go
+++ b/githubbot/githubbot/util.go
@@ -142,13 +142,13 @@ func formatCheckRunMessage(evt *github.CheckRunEvent, username string) (res stri
 			}
 		}
 		if strings.HasPrefix(username, "@") && isPullRequest && res != "" {
-			res = res + "\n" + username
+			res = fmt.Sprintf("%s\n%s", res, username)
 		}
 	}
 	return res
 }
 
-func formatStatusMessage(evt *github.StatusEvent, pullRequests []*github.PullRequest, username string) (res string) {
+func formatStatusMessage(evt *github.StatusEvent, pullRequests []*github.PullRequest, username string) (res string, err error) {
 	state := evt.GetState()
 	repo := evt.GetRepo().GetName()
 	isPullRequest := len(pullRequests) > 0
@@ -190,7 +190,7 @@ func formatStatusMessage(evt *github.StatusEvent, pullRequests []*github.PullReq
 		}
 	}
 	if strings.HasPrefix(username, "@") && isPullRequest && res != "" {
-		res = res + "\n" + username
+		res = fmt.Sprintf("%s\n%s", res, username)
 	}
 	return res
 }

--- a/githubbot/githubbot/util.go
+++ b/githubbot/githubbot/util.go
@@ -154,7 +154,7 @@ func formatStatusMessage(evt *github.StatusEvent, pullRequests []*github.PullReq
 	isPullRequest := len(pullRequests) > 0
 	var branch string
 	if len(evt.Branches) < 1 {
-		return
+		return ""
 	}
 	branch = evt.Branches[0].GetName()
 	var testName string

--- a/githubbot/main.go
+++ b/githubbot/main.go
@@ -127,6 +127,10 @@ Examples:%s
 				MobileBody:  mentionsExtended,
 			},
 		},
+		{
+			Name:        "github auth",
+			Description: "Check if GitHub is authenticated for your account.",
+		},
 	}
 	return kbchat.Advertisement{
 		Alias: "GitHub",

--- a/githubbot/main.go
+++ b/githubbot/main.go
@@ -214,7 +214,7 @@ func (s *BotServer) Go() (err error) {
 	config := &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		Scopes:       []string{"admin:repo_hook"},
+		Scopes:       []string{"repo"},
 		Endpoint:     oauth2github.Endpoint,
 		RedirectURL:  s.opts.HTTPPrefix + "/githubbot/oauth",
 	}


### PR DESCRIPTION
This PR changes a bunch of stuff to make it possible to parse CI events using the Status API and read PR information from private repos:
* parses CheckRun and Status events instead of CheckSuite events
* fetches oauth token for convID before formatting messages in `http.go`
* stores the oauth identifier in the `subscriptions` table to allow convID => token fetching
* bolds GitHub usernames for better readability
* adds `!github auth` command for checking github auth without subscribing