### PR TITLE
Migrate to Github Apps API, add event preferences

### DIFF
--- a/base/oauth.go
+++ b/base/oauth.go
@@ -170,7 +170,7 @@ func GetOAuthClient(
 				return nil, err
 			}
 			if !isAdmin {
-				_, err = kbc.SendMessageByConvID(callbackMsg.ConvID, "You have must be an admin to authorize me for a team!")
+				_, err = kbc.SendMessageByConvID(callbackMsg.ConvID, "You must be an admin to authorize me for a team!")
 				return nil, err
 			}
 		}

--- a/githubbot/README.md
+++ b/githubbot/README.md
@@ -33,7 +33,7 @@ In order to run the GitHub bot, you will need
   keybase chat api -m '{"method": "clearcommands"}'
   ```
 - You can optionally save your GitHub app details inside your bot account's private KBFS folder. To do this, create a `credentials.json` file in `/keybase/private/<YourGitHubBot>` (or the equivalent KBFS path on your system) that matches the following format:
-  ```json
+  ```js
   {
     "app_name": "your URL-safe GitHub app name",
     "app_id": 12345, // your GitHub app ID

--- a/githubbot/README.md
+++ b/githubbot/README.md
@@ -7,8 +7,9 @@ A Keybase chat bot that notifies a channel when an event happens on a GitHub rep
 In order to run the GitHub bot, you will need
 
 - a running MySQL database in order to store GitHub OAuth tokens, user preferences, and channel subscriptions
-- the client ID and client secret from a [GitHub OAuth application](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/)
-- an arbitrary secret, used to authenticate webhooks from GitHub (this can be any string)
+- the app ID, app name, client ID, and client secret from a [GitHub app](https://developer.github.com/apps/building-github-apps/creating-a-github-app/)
+- a [secret string](https://developer.github.com/webhooks/securing), used to authenticate webhooks from GitHub. Remember to update the webhook secret on your Github app to this string!
+- the private key `.pem` file from your GitHub app
 
 ## Running
 
@@ -17,28 +18,31 @@ In order to run the GitHub bot, you will need
    ```
    go install .
    ```
-3. The GitHub bot sets itself up to serve HTTP requests on `/githubbot` plus a prefix indicating what the URLs will look like. The HTTP server runs on port 8080. You can configure nginx or any other reverse proxy software to route to this port and path. Make sure the callback url for your GitHub app is set to `http://<your web server>/githubbot/oauth`.
+3. The GitHub bot sets itself up to serve HTTP requests on `/githubbot` plus a prefix indicating what the URLs will look like. The HTTP server runs on port 8080. You can configure nginx or any other reverse proxy software to route to this port and path. Make sure the callback URL for your GitHub app is set to `http://<your web server>/githubbot/oauth`, and the webhook URL is set to `http://<your web server>/githubbot/webhook`.
 4. To start the GitHub bot, run a command like this:
    ```
-   $GOPATH/bin/githubbot --http-prefix 'http://<your web server>:8080' --dsn 'root@/githubbot' --client-id '<OAuth client ID>' --client-secret '<OAuth client secret>' --secret '<your secret string>'
+   $GOPATH/bin/githubbot --http-prefix 'http://<your web server>:8080' --dsn 'root@/githubbot' --app-name 'my-bot' --app-id 12345 --client-id '<OAuth client ID>' --client-secret '<OAuth client secret>' --secret '<your secret string>' --private-key-path '/path/to/bot.private-key.pem'
    ```
 5. Run `githubbot --help` for more options.
 
 ### Helpful Tips
 
+- Remember to configure the permissions for your GitHub app. The bot expects read-only access to checks, contents, issues, pull requests, and commit statuses, as well as the webhook events for check runs, issues, pushes, statuses, and pull requests.
 - If you accidentally run the bot under your own username and wish to clear the `!` commands, run the following:
   ```
   keybase chat api -m '{"method": "clearcommands"}'
   ```
-- You can optionally save your GitHub OAuth ID and secret inside your bot account's private KBFS folder. To do this, create a `credentials.json` file in `/keybase/private/<YourGitHubBot>` (or the equivalent KBFS path on your system) that matches the following format:
+- You can optionally save your GitHub app details inside your bot account's private KBFS folder. To do this, create a `credentials.json` file in `/keybase/private/<YourGitHubBot>` (or the equivalent KBFS path on your system) that matches the following format:
   ```json
   {
+    "app_name": "your URL-safe GitHub app name",
+    "app_id": 12345, // your GitHub app ID
     "client_id": "your GitHub OAuth client ID here",
     "client_secret": "your GitHub OAuth client secret here"
   }
   ```
-  If you have KBFS running, you can now run the bot without providing the `--client-id` and `--client-secret` command line options.
-- You can also store your bot secret in KBFS by saving it in a file named `bot.secret` in your bot account's private KBFS folder and omitting the `--secret` command line argument.
+  If you have KBFS running, you can now run the bot without providing the `--client-id`, `--client-secret`, `--app-id`, and `--app-name` command line options.
+- You can store your bot secret in KBFS by saving it in a file named `bot.secret` and omitting the `--secret` command line argument, and your private key file in a file named `bot.private-key.pem` and omitting the `--private-key-path` argument.
 
 ### Docker
 

--- a/githubbot/db.sql
+++ b/githubbot/db.sql
@@ -10,10 +10,25 @@ CREATE TABLE `oauth` (
 CREATE TABLE `subscriptions` (
   `conv_id` char(64) NOT NULL,
   `repo` varchar(128) NOT NULL,
+  `installation_id` bigint(20) NOT NULL,
+  UNIQUE KEY unique_subscription (`conv_id`, `repo`) 
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `branches` (
+  `conv_id` char(64) NOT NULL,
+  `repo` varchar(128) NOT NULL,
   `branch` varchar(128) NOT NULL,
-  `hook_id` bigint(20) NOT NULL,
-  `oauth_identifier` varchar(128) NOT NULL,
-  UNIQUE KEY unique_subscription (`conv_id`, `repo`, `branch`) 
+  UNIQUE KEY unique_subscription (`conv_id`, `repo`, `branch`)  
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `features` (
+  `conv_id` char(64) NOT NULL,
+  `repo` varchar(128) NOT NULL,
+  `issues` boolean NOT NULL DEFAULT 1,
+  `pull_requests` boolean NOT NULL DEFAULT 1,
+  `commits` boolean NOT NULL DEFAULT 0,
+  `statuses` boolean NOT NULL DEFAULT 1,
+  UNIQUE KEY unique_subscription (`conv_id`, `repo`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `user_prefs` (
@@ -21,3 +36,5 @@ CREATE TABLE `user_prefs` (
   `mention` tinyint(1) NOT NULL,
   PRIMARY KEY (`username`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+

--- a/githubbot/db.sql
+++ b/githubbot/db.sql
@@ -36,5 +36,3 @@ CREATE TABLE `user_prefs` (
   `mention` tinyint(1) NOT NULL,
   PRIMARY KEY (`username`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -222,7 +222,7 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 }
 
 func (h *Handler) handleSubscribeToFeature(repo string, feature string, msg chat1.MsgSummary, enable bool) (err error) {
-	// TODO: make sure user is authed here too
+	// isAdmin is checked in handleSubscribe
 	var message string
 	defer func() {
 		if message != "" {
@@ -282,7 +282,7 @@ func (h *Handler) handleSubscribeToFeature(repo string, feature string, msg chat
 }
 
 func (h *Handler) handleSubscribeToBranch(repo string, branch string, msg chat1.MsgSummary, create bool) (err error) {
-	// TODO: make sure user is authed here too
+	// isAdmin is checked in handleSubscribe
 	var message string
 	defer func() {
 		if message != "" {

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -107,7 +107,17 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 
 	args := toks[2:]
 	if len(args) < 1 {
-		return fmt.Errorf("bad args for subscribe: %v", args)
+		var message string
+		if create {
+			message = "I don't understand! Try `!github subscribe <username/repo>`"
+		} else {
+			message = "I don't understand! Try `!github unsubscribe <username/repo>`"
+		}
+		_, err = h.kbc.SendMessageByConvID(msg.ConvID, message)
+		if err != nil {
+			err = fmt.Errorf("error sending message: %s", err)
+		}
+		return err
 	}
 
 	// Check if command is subscribing to a branch
@@ -141,9 +151,9 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 	parsedRepo := strings.Split(args[0], "/")
 	if len(parsedRepo) != 2 {
 		if create {
-			message = "`%s` doesn't look like a repository to me! Try sending `!github subscribe <owner/repository>`"
+			message = "`%s` doesn't look like a repository to me! Try sending `!github subscribe <username/repo>`"
 		} else {
-			message = "`%s` doesn't look like a repository to me! Try sending `!github unsubscribe <owner/repository>`"
+			message = "`%s` doesn't look like a repository to me! Try sending `!github unsubscribe <username/repo>`"
 		}
 		return nil
 	}

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -25,12 +25,13 @@ type Handler struct {
 	config     *oauth2.Config
 	atr        *ghinstallation.AppsTransport
 	httpPrefix string
+	appName    string
 	secret     string
 }
 
 var _ base.Handler = (*Handler)(nil)
 
-func NewHandler(kbc *kbchat.API, db *DB, requests *base.OAuthRequests, config *oauth2.Config, atr *ghinstallation.AppsTransport, httpPrefix string, secret string) *Handler {
+func NewHandler(kbc *kbchat.API, db *DB, requests *base.OAuthRequests, config *oauth2.Config, atr *ghinstallation.AppsTransport, httpPrefix string, appName string, secret string) *Handler {
 	return &Handler{
 		DebugOutput: base.NewDebugOutput("Handler", kbc),
 		kbc:         kbc,
@@ -39,12 +40,16 @@ func NewHandler(kbc *kbchat.API, db *DB, requests *base.OAuthRequests, config *o
 		config:      config,
 		atr:         atr,
 		httpPrefix:  httpPrefix,
+		appName:     appName,
 		secret:      secret,
 	}
 }
 
 func (h *Handler) HandleNewConv(conv chat1.ConvSummary) error {
-	welcomeMsg := "Hi! I can notify you whenever something happens on a GitHub repository. To get started, install the Keybase integration on your repository, then send `!github subscribe <username/repo>`\n"
+	welcomeMsg := fmt.Sprintf(
+		"Hi! I can notify you whenever something happens on a GitHub repository. To get started, install the Keybase integration on your repository, then send `!github subscribe <username/repo>`\n\ngithub.com/apps/%s/installations/new",
+		h.appName,
+	)
 	return base.HandleNewTeam(h.DebugOutput, h.kbc, conv, welcomeMsg)
 }
 

--- a/githubbot/githubbot/util.go
+++ b/githubbot/githubbot/util.go
@@ -189,3 +189,19 @@ func getPossibleKBUser(kbc *kbchat.API, d *DB, debug *base.DebugOutput, githubUs
 
 	return u
 }
+
+// pref checking
+func shouldParseEvent(event interface{}, features *Features) bool {
+	switch event.(type) {
+	case *github.IssuesEvent:
+		return features.Issues
+	case *github.PullRequestEvent:
+		return features.PullRequests
+	case *github.PushEvent:
+		return features.Commits
+	case *github.CheckRunEvent, *github.StatusEvent:
+		return features.Statuses
+	default:
+		return false
+	}
+}

--- a/githubbot/main.go
+++ b/githubbot/main.go
@@ -56,20 +56,20 @@ const backs = "```"
 
 func (s *BotServer) makeAdvertisement() kbchat.Advertisement {
 	subExtended := fmt.Sprintf(`Enables posting updates from the provided GitHub repository to this conversation.
+Event type must be one of %sissues, pulls, commits, statuses%s
 
-Example:%s
-!github subscribe keybase/client%s
-
-Subscribe to a specific branch:%s
+Examples:%s
+!github subscribe keybase/client
+!github subscribe microsoft/typescript pulls
 !github subscribe facebook/react gh-pages%s`,
 		backs, backs, backs, backs)
 
 	unsubExtended := fmt.Sprintf(`Disables updates from the provided GitHub repository to this conversation.
+Event type must be one of %sissues, pulls, commits, statuses%s
 
-Example:%s
-!github unsubscribe keybase/client%s
-
-Unsubscribe from a specific branch:%s
+Examples:%s
+!github unsubscribe keybase/client
+!github unsubscribe microsoft/typescript commits
 !github unsubscribe facebook/react gh-pages%s`,
 		backs, backs, backs, backs)
 
@@ -85,7 +85,7 @@ Examples:%s
 			Name:        "github subscribe",
 			Description: "Enable updates from GitHub repos",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title:       `*!github subscribe* <username/repo> [branch]`,
+				Title:       `*!github subscribe* <username/repo> [branch or event type]`,
 				DesktopBody: subExtended,
 				MobileBody:  subExtended,
 			},
@@ -94,7 +94,7 @@ Examples:%s
 			Name:        "github unsubscribe",
 			Description: "Disable updates from GitHub repos",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title:       `*!github unsubscribe* <username/repo> [branch]`,
+				Title:       `*!github unsubscribe* <username/repo> [branch or event type]`,
 				DesktopBody: unsubExtended,
 				MobileBody:  unsubExtended,
 			},

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.28.1
+	github.com/bradleyfalzon/ghinstallation v1.1.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/google/go-github/v28 v28.1.1

--- a/go.sum
+++ b/go.sum
@@ -5,11 +5,15 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/aws/aws-sdk-go v1.28.1 h1:aWBD5EJrmGFuHFn9ZdaHqWWZGZYQ5Gzb3j9G0RppLpY=
 github.com/aws/aws-sdk-go v1.28.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/bradleyfalzon/ghinstallation v1.1.0 h1:mwazVinJU0mPyLxIcdtJzu4DhWXFO5lMsWhKyFRIwFk=
+github.com/bradleyfalzon/ghinstallation v1.1.0/go.mod h1:p7iD8KytOOKg2wCqbwvJlq4JGpYMjwjkiqdyUqOIHLI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
@@ -23,6 +27,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github/v28 v28.1.1 h1:kORf5ekX5qwXO2mGzXXOjMe/g6ap8ahVe0sBEulhSxo=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=


### PR DESCRIPTION
This is a large refactor of how the bot authenticates with the GitHub API and how messages are handled. Overview of the changes:

* The webhook handler now authenticates and gets conversations with the repo and installation ID 
* User-based OAuth is now linked 1-1 from keybase user to github oauth token. These tokens are only used to make sure you're authorized to link a GitHub app installation with a conversation ID.
* Subscriptions are now `(conv_id, repo, installation_id)`. Branches have been moved to a new `branches` table, and are only used to keep track of which push events to send notifications for. 
* There is a new `features` table which keeps track of which events should be parsed for a given `(conv_id, repo)` pair. The un/subscribe commands now can take either an event type or a branch name.

### todo
* [x] update installation instructions