### PR TITLE
feat: read webhook secret from credentials.json

### DIFF
--- a/githubbot/README.md
+++ b/githubbot/README.md
@@ -38,11 +38,12 @@ In order to run the GitHub bot, you will need
     "app_name": "your URL-safe GitHub app name",
     "app_id": 12345, // your GitHub app ID
     "client_id": "your GitHub OAuth client ID here",
-    "client_secret": "your GitHub OAuth client secret here"
+    "client_secret": "your GitHub OAuth client secret here",
+    "webhook_secret": "your secret here"
   }
   ```
-  If you have KBFS running, you can now run the bot without providing the `--client-id`, `--client-secret`, `--app-id`, and `--app-name` command line options.
-- You can store your bot secret in KBFS by saving it in a file named `bot.secret` and omitting the `--secret` command line argument, and your private key file in a file named `bot.private-key.pem` and omitting the `--private-key-path` argument.
+  If you have KBFS running, you can now run the bot without providing the `--client-id`, `--client-secret`, `--app-id`, `--app-name`, and `--secret` command line options.
+- You can store your private key file in KBFS by saving it in a file named `bot.private-key.pem` and omitting the `--private-key-path` argument.
 
 ### Docker
 

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -26,14 +26,13 @@ type Handler struct {
 	atr         *ghinstallation.AppsTransport
 	httpPrefix  string
 	appName     string
-	secret      string
 }
 
 var _ base.Handler = (*Handler)(nil)
 
 func NewHandler(kbc *kbchat.API, debugConfig *base.ChatDebugOutputConfig, db *DB, requests *base.OAuthRequests,
 	oauthConfig *oauth2.Config, atr *ghinstallation.AppsTransport,
-	httpPrefix, appName, secret string) *Handler {
+	httpPrefix, appName string) *Handler {
 	return &Handler{
 		DebugOutput: base.NewDebugOutput("Handler", debugConfig),
 		kbc:         kbc,
@@ -43,7 +42,6 @@ func NewHandler(kbc *kbchat.API, debugConfig *base.ChatDebugOutputConfig, db *DB
 		atr:         atr,
 		httpPrefix:  httpPrefix,
 		appName:     appName,
-		secret:      secret,
 	}
 }
 

--- a/gitlabbot/README.md
+++ b/gitlabbot/README.md
@@ -5,7 +5,7 @@ A Keybase chat bot that notifies a channel when an event happens on a GitLab pro
 ## GitLab API
 
 The one scope needed for GitLab bot is: `api`. For more information on GitLab scopes visit the GitLab
-[docs](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#limiting-scopes-of-a-personal-access-token). 
+[docs](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#limiting-scopes-of-a-personal-access-token).
 
 In GitLab's OAuth Application dashboard specify the Callback URL: `https://<YOUR_DOMAIN>/gitlabbot/oauth`
 which is needed for the redirect in the OAuth flow.
@@ -41,15 +41,15 @@ In order to run the GitLab bot, you will need
   ```
   keybase chat api -m '{"method": "clearcommands"}'
   ```
-- You can optionally save your GitLab OAuth ID and secret inside your bot account's private KBFS folder. To do this, create a `credentials.json` file in `/keybase/private/<YourGitLabBot>` (or the equivalent KBFS path on your system) that matches the following format:
+- You can optionally save your GitLab OAuth ID , OAuth secret, and bot secret inside your bot account's private KBFS folder. To do this, create a `credentials.json` file in `/keybase/private/<YourGitLabBot>` (or the equivalent KBFS path on your system) that matches the following format:
   ```json
   {
     "client_id": "your GitLab OAuth client ID here",
-    "client_secret": "your GitLab OAuth client secret here"
+    "client_secret": "your GitLab OAuth client secret here",
+    "webhook_secret": "your secret here"
   }
   ```
-  If you have KBFS running, you can now run the bot without providing the `--client-id` and `--client-secret` command line options.
-- You can also store your bot secret in KBFS by saving it in a file named `bot.secret` in your bot account's private KBFS folder and omitting the `--secret` command line argument.
+  If you have KBFS running, you can now run the bot without providing the `--client-id`, `--client-secret`, and `--secret` command line options.
 
 ### Docker
 


### PR DESCRIPTION
There was a bug where reading the bot secret from its own file would add an extra newline character, causing signature verifications to fail. This PR moves the bot secret into credentials.json alongside other config options. cc @Daniel-Wang 