### PR TITLE
Remove OAuth For GitLab bot

### DIFF
--- a/gitlabbot/README.md
+++ b/gitlabbot/README.md
@@ -2,22 +2,11 @@
 
 A Keybase chat bot that notifies a channel when an event happens on a GitLab project (issues, pull requests, commits, etc.).
 
-## GitLab API
-
-The one scope needed for GitLab bot is: `api`. For more information on GitLab scopes visit the GitLab
-[docs](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#limiting-scopes-of-a-personal-access-token).
-
-In GitLab's OAuth Application dashboard specify the Callback URL: `https://<YOUR_DOMAIN>/gitlabbot/oauth`
-which is needed for the redirect in the OAuth flow.
-
-> Note `<YOUR_DOMAIN>` should reflect where GitLab bot is running (same as `http-prefix` flag under **Running**)
-
 ## Prerequisites
 
 In order to run the GitLab bot, you will need
 
-- A running MySQL database in order to store GitLab OAuth tokens, user preferences, and channel subscriptions
-- The client ID and client secret from a [GitLab OAuth application](https://docs.gitlab.com/ee/integration/oauth_provider.html)
+- A running MySQL database in order to store user preferences, and channel subscriptions
 - An arbitrary secret, used to authenticate webhooks from GitLab (this can be any string)
 
 ## Running
@@ -30,7 +19,7 @@ In order to run the GitLab bot, you will need
 3. The GitLab bot sets itself up to serve HTTP requests on `/gitlabbot` plus a prefix indicating what the URLs will look like. The HTTP server runs on port 8080. You can configure nginx or any other reverse proxy software to route to this port and path. Make sure the callback url for your GitLab app is set to `http://<your web server>/gitlabbot/oauth`.
 4. To start the GitLab bot, run a command like this:
    ```
-   $GOPATH/bin/gitlabbot --http-prefix 'http://<YOUR_DOMAIN>:8080' --dsn 'root@/gitlabbot' --client-id '<OAuth client ID>' --client-secret '<OAuth client secret>' --secret '<your secret string>'
+   $GOPATH/bin/gitlabbot --http-prefix 'http://<YOUR_DOMAIN>:8080' --dsn 'root@/gitlabbot' --secret '<your secret string>'
    ```
 5. Run `gitlabbot --help` for more options.
 
@@ -41,15 +30,13 @@ In order to run the GitLab bot, you will need
   ```
   keybase chat api -m '{"method": "clearcommands"}'
   ```
-- You can optionally save your GitLab OAuth ID , OAuth secret, and bot secret inside your bot account's private KBFS folder. To do this, create a `credentials.json` file in `/keybase/private/<YourGitLabBot>` (or the equivalent KBFS path on your system) that matches the following format:
+- You can optionally save your bot secret inside your bot account's private KBFS folder. To do this, create a `credentials.json` file in `/keybase/private/<YourGitLabBot>` (or the equivalent KBFS path on your system) that matches the following format:
   ```json
   {
-    "client_id": "your GitLab OAuth client ID here",
-    "client_secret": "your GitLab OAuth client secret here",
     "webhook_secret": "your secret here"
   }
   ```
-  If you have KBFS running, you can now run the bot without providing the `--client-id`, `--client-secret`, and `--secret` command line options.
+  If you have KBFS running, you can now run the bot without providing `--secret` command line options.
 
 ### Docker
 

--- a/gitlabbot/db.sql
+++ b/gitlabbot/db.sql
@@ -11,7 +11,6 @@ CREATE TABLE `subscriptions` (
   `conv_id` char(64) NOT NULL,
   `repo` varchar(128) NOT NULL,
   `branch` varchar(128) NOT NULL,
-  `hook_id` bigint(20) NOT NULL,
   `oauth_identifier` varchar(128) NOT NULL,
   UNIQUE KEY unique_subscription (`conv_id`, `repo`, `branch`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/gitlabbot/gitlabbot/db.go
+++ b/gitlabbot/gitlabbot/db.go
@@ -26,6 +26,8 @@ func (d *DB) CreateSubscription(convID chat1.ConvIDStr, repo string, branch stri
 			INSERT INTO subscriptions
 			(conv_id, repo, branch, oauth_identifier)
 			VALUES
+			ON DUPLICATE KEY UPDATE
+			oauth_identifier=VALUES(oauth_identifier)
 			(?, ?, ?, ?)
 		`, convID, repo, branch, oauthIdentifier)
 		return err

--- a/gitlabbot/gitlabbot/db.go
+++ b/gitlabbot/gitlabbot/db.go
@@ -20,16 +20,14 @@ func NewDB(db *sql.DB) *DB {
 
 // webhook subscription methods
 
-func (d *DB) CreateSubscription(convID chat1.ConvIDStr, repo string, branch string, hookID int64, oauthIdentifier string) error {
+func (d *DB) CreateSubscription(convID chat1.ConvIDStr, repo string, branch string, oauthIdentifier string) error {
 	return d.RunTxn(func(tx *sql.Tx) error {
 		_, err := tx.Exec(`
 			INSERT INTO subscriptions
-			(conv_id, repo, branch, hook_id, oauth_identifier)
+			(conv_id, repo, branch, oauth_identifier)
 			VALUES
-			(?, ?, ?, ?, ?)
-			ON DUPLICATE KEY UPDATE
-			hook_id=VALUES(hook_id)
-		`, convID, repo, branch, hookID, oauthIdentifier)
+			(?, ?, ?, ?)
+		`, convID, repo, branch, oauthIdentifier)
 		return err
 	})
 }
@@ -109,20 +107,6 @@ func (d *DB) GetSubscriptionForRepoExists(convID chat1.ConvIDStr, repo string) (
 	default:
 		return false, err
 	}
-}
-
-func (d *DB) GetHookIDForRepo(convID chat1.ConvIDStr, repo string) (hookID int64, err error) {
-	row := d.DB.QueryRow(`
-	SELECT hook_id
-	FROM subscriptions
-	WHERE (conv_id = ? AND repo = ?)
-	`, convID, repo)
-	err = row.Scan(&hookID)
-	if err != nil {
-		return -1, err
-	}
-
-	return hookID, nil
 }
 
 // OAuth2 token methods

--- a/gitlabbot/gitlabbot/handler.go
+++ b/gitlabbot/gitlabbot/handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/keybase/go-keybase-chat-bot/kbchat"
 	"github.com/keybase/go-keybase-chat-bot/kbchat/types/chat1"
 	"github.com/keybase/managed-bots/base"
-	"golang.org/x/oauth2"
 )
 
 type Handler struct {
@@ -16,8 +15,6 @@ type Handler struct {
 
 	kbc        *kbchat.API
 	db         *DB
-	requests   *base.OAuthRequests
-	config     *oauth2.Config
 	httpPrefix string
 	secret     string
 }
@@ -25,13 +22,11 @@ type Handler struct {
 var _ base.Handler = (*Handler)(nil)
 
 func NewHandler(kbc *kbchat.API, debugConfig *base.ChatDebugOutputConfig,
-	db *DB, requests *base.OAuthRequests, config *oauth2.Config, httpPrefix string, secret string) *Handler {
+	db *DB, httpPrefix string, secret string) *Handler {
 	return &Handler{
 		DebugOutput: base.NewDebugOutput("Handler", debugConfig),
 		kbc:         kbc,
 		db:          db,
-		requests:    requests,
-		config:      config,
 		httpPrefix:  httpPrefix,
 		secret:      secret,
 	}
@@ -110,7 +105,7 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool)
 
 			_, err = h.kbc.SendMessageByConvID(msg.ConvID, formatSetupInstructions(args[0], msg, h.httpPrefix, h.secret))
 			if err != nil {
-				err = fmt.Errorf("error sending message: %s", err)
+				return fmt.Errorf("error sending message: %s", err)
 			}
 
 			return nil

--- a/gitlabbot/gitlabbot/handler.go
+++ b/gitlabbot/gitlabbot/handler.go
@@ -2,12 +2,9 @@ package gitlabbot
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/kballard/go-shellquote"
-	"github.com/xanzy/go-gitlab"
-
 	"github.com/keybase/go-keybase-chat-bot/kbchat"
 	"github.com/keybase/go-keybase-chat-bot/kbchat/types/chat1"
 	"github.com/keybase/managed-bots/base"
@@ -59,33 +56,16 @@ func (h *Handler) HandleCommand(msg chat1.MsgSummary) error {
 		return nil
 	}
 
-	identifier := base.IdentifierFromMsg(msg)
-	tc, err := base.GetOAuthClient(identifier, msg, h.kbc, h.requests, h.config, h.db,
-		base.GetOAuthOpts{
-			AuthMessageTemplate: "Visit %s\n to authorize me to set up GitLab notifications.",
-		})
-	if err != nil || tc == nil {
-		return err
-	}
-
-	token, err := h.db.GetToken(identifier)
-	if err != nil {
-		h.Errorf("error getting token from db")
-		return err
-	}
-
-	client := gitlab.NewOAuthClient(tc, token.AccessToken)
-
 	switch {
 	case strings.HasPrefix(cmd, "!gitlab subscribe"):
-		return h.handleSubscribe(cmd, msg, true, client)
+		return h.handleSubscribe(cmd, msg, true)
 	case strings.HasPrefix(cmd, "!gitlab unsubscribe"):
-		return h.handleSubscribe(cmd, msg, false, client)
+		return h.handleSubscribe(cmd, msg, false)
 	}
 	return nil
 }
 
-func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool, client *gitlab.Client) (err error) {
+func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool) (err error) {
 	toks, err := shellquote.Split(cmd)
 	if err != nil {
 		return fmt.Errorf("error splitting command: %s", err)
@@ -97,7 +77,7 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 
 	// Check if command is subscribing to a branch
 	if len(toks) == 4 {
-		return h.handleSubscribeToBranch(cmd, msg, create, client)
+		return h.handleSubscribeToBranch(cmd, msg, create)
 	}
 
 	var message string
@@ -121,44 +101,18 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 	}
 	if create {
 		if !alreadyExists {
-			project, err := getProject(args[0], client)
-			if err != nil {
-				return fmt.Errorf("error getting gitlab project: %s", err)
-			}
+			defaultBranch := "master"
 
-			webhookURL := h.httpPrefix + "/gitlabbot/webhook"
-			eventsFlag := true
-			token := base.MakeSecret(args[0], msg.ConvID, h.secret)
-			defaultBranch := project.DefaultBranch
-
-			hook, res, err := client.Projects.AddProjectHook(args[0], &gitlab.AddProjectHookOptions{
-				URL:                      &webhookURL,
-				PushEvents:               &eventsFlag,
-				IssuesEvents:             &eventsFlag,
-				ConfidentialIssuesEvents: &eventsFlag,
-				MergeRequestsEvents:      &eventsFlag,
-				PipelineEvents:           &eventsFlag,
-				EnableSSLVerification:    nil,
-				Token:                    &token,
-			})
-
-			if err != nil {
-				switch res.StatusCode {
-				case http.StatusNotFound:
-					message = "I couldn't subscribe to updates on %s, do you have the right permissions?"
-					return nil
-				case http.StatusUnprocessableEntity:
-					message = "I couldn't create a webhook on %s, try deleting Keybase webhooks in your project's settings and try again."
-					return nil
-				default:
-					return fmt.Errorf("error: %s", err)
-				}
-			}
-			err = h.db.CreateSubscription(msg.ConvID, args[0], defaultBranch, int64(hook.ID), base.IdentifierFromMsg(msg))
+			err = h.db.CreateSubscription(msg.ConvID, args[0], defaultBranch, base.IdentifierFromMsg(msg))
 			if err != nil {
 				return fmt.Errorf("error creating subscription: %s", err)
 			}
-			message = "Okay, you'll receive updates for %s here."
+
+			_, err = h.kbc.SendMessageByConvID(msg.ConvID, formatSetupInstructions(args[0], msg, h.httpPrefix, h.secret))
+			if err != nil {
+				err = fmt.Errorf("error sending message: %s", err)
+			}
+
 			return nil
 		}
 
@@ -167,16 +121,6 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 	}
 
 	if alreadyExists {
-		hookID, err := h.db.GetHookIDForRepo(msg.ConvID, args[0])
-		if err != nil {
-			return fmt.Errorf("error getting hook ID for subscription: %s", err)
-		}
-
-		_, err = client.Projects.DeleteProjectHook(args[0], int(hookID))
-		if err != nil {
-			return fmt.Errorf("error deleting webhook: %s", err)
-		}
-
 		err = h.db.DeleteSubscriptionsForRepo(msg.ConvID, args[0])
 		if err != nil {
 			return fmt.Errorf("error deleting subscriptions: %s", err)
@@ -189,7 +133,7 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 	return nil
 }
 
-func (h *Handler) handleSubscribeToBranch(cmd string, msg chat1.MsgSummary, create bool, client *gitlab.Client) (err error) {
+func (h *Handler) handleSubscribeToBranch(cmd string, msg chat1.MsgSummary, create bool) (err error) {
 	toks, err := shellquote.Split(cmd)
 	if err != nil {
 		return fmt.Errorf("error splitting command: %s", err)
@@ -209,11 +153,7 @@ func (h *Handler) handleSubscribeToBranch(cmd string, msg chat1.MsgSummary, crea
 		return fmt.Errorf("bad args for subscribe to branch: %v", args)
 	}
 
-	project, err := getProject(args[0], client)
-	if err != nil {
-		return fmt.Errorf("error getting gitlab project: %s", err)
-	}
-	var defaultBranch = project.DefaultBranch
+	defaultBranch := "master"
 
 	if exists, err := h.db.GetSubscriptionExists(msg.ConvID, args[0], defaultBranch); !exists {
 		if err != nil {
@@ -233,12 +173,7 @@ func (h *Handler) handleSubscribeToBranch(cmd string, msg chat1.MsgSummary, crea
 	}
 
 	if create {
-		hookID, err := h.db.GetHookIDForRepo(msg.ConvID, args[0])
-		if err != nil {
-			return fmt.Errorf("error getting hook ID for subscription: %s", err)
-		}
-
-		err = h.db.CreateSubscription(msg.ConvID, args[0], args[1], hookID, base.IdentifierFromMsg(msg))
+		err = h.db.CreateSubscription(msg.ConvID, args[0], args[1], base.IdentifierFromMsg(msg))
 		if err != nil {
 			return fmt.Errorf("error creating subscription: %s", err)
 		}

--- a/gitlabbot/gitlabbot/http.go
+++ b/gitlabbot/gitlabbot/http.go
@@ -11,11 +11,10 @@ import (
 
 	"github.com/keybase/go-keybase-chat-bot/kbchat"
 	"github.com/keybase/managed-bots/base"
-	"golang.org/x/oauth2"
 )
 
 type HTTPSrv struct {
-	*base.OAuthHTTPSrv
+	*base.HTTPSrv
 
 	kbc     *kbchat.API
 	db      *DB
@@ -24,15 +23,14 @@ type HTTPSrv struct {
 }
 
 func NewHTTPSrv(kbc *kbchat.API, debugConfig *base.ChatDebugOutputConfig,
-	db *DB, handler *Handler, requests *base.OAuthRequests, config *oauth2.Config, secret string) *HTTPSrv {
+	db *DB, handler *Handler, secret string) *HTTPSrv {
 	h := &HTTPSrv{
 		kbc:     kbc,
 		db:      db,
 		handler: handler,
 		secret:  secret,
 	}
-	h.OAuthHTTPSrv = base.NewOAuthHTTPSrv(kbc, debugConfig, config, requests, h.db, h.handler.HandleAuth,
-		"gitlabbot", base.Images["logo"], "/gitlabbot")
+	h.HTTPSrv = base.NewHTTPSrv(debugConfig)
 	http.HandleFunc("/gitlabbot", h.handleHealthCheck)
 	http.HandleFunc("/gitlabbot/webhook", h.handleWebhook)
 	return h

--- a/gitlabbot/gitlabbot/util.go
+++ b/gitlabbot/gitlabbot/util.go
@@ -3,6 +3,7 @@ package gitlabbot
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/keybase/go-keybase-chat-bot/kbchat/types/chat1"
 	"github.com/xanzy/go-gitlab"
 	"net/http"
 	"strings"
@@ -54,6 +55,20 @@ func formatPipelineMsg(evt *gitlab.PipelineEvent, username string) (res string) 
 		res = res + "\n" + username
 	}
 	return res
+}
+
+func formatSetupInstructions(repo string, msg chat1.MsgSummary, httpAddress string, secret string) (res string) {
+	back := "`"
+	message := fmt.Sprintf(`
+To configure your project to send notifications, go to https://gitlab.com/%s/-/settings/integrations and add a new webhook.
+For “URL”, enter %s%s/gitlabbot/webhook%s.
+For “Secret Token”, enter %s%s%s.
+Remember to check all the triggers you would like me to update you on.
+Note that I currently support the following Webhook Events: Push, Issues, Merge Request, Pipeline
+
+Happy coding!`,
+		repo, back, httpAddress, back, back, base.MakeSecret(repo, msg.ConvID, secret), back)
+	return message
 }
 
 func getProject(repo string, client *gitlab.Client) (*gitlab.Project, error) {

--- a/gitlabbot/gitlabbot/util.go
+++ b/gitlabbot/gitlabbot/util.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/keybase/go-keybase-chat-bot/kbchat/types/chat1"
 	"github.com/xanzy/go-gitlab"
-	"net/http"
 	"strings"
 
 	"github.com/keybase/go-keybase-chat-bot/kbchat"
@@ -69,19 +68,6 @@ Note that I currently support the following Webhook Events: Push, Issues, Merge 
 Happy coding!`,
 		repo, back, httpAddress, back, back, base.MakeSecret(repo, msg.ConvID, secret), back)
 	return message
-}
-
-func getProject(repo string, client *gitlab.Client) (*gitlab.Project, error) {
-	if client == nil {
-		return nil, fmt.Errorf("getDefaultBranch: client is nil")
-	}
-
-	project, res, err := client.Projects.GetProject(repo, &gitlab.GetProjectOptions{})
-	if err != nil || res.StatusCode != http.StatusOK {
-		return nil, err
-	}
-
-	return project, nil
 }
 
 // keybase IDing


### PR DESCRIPTION
GitLab's API scope gives too much control to the bot, so we will scrap the current flow

New Flow:

1. GitLab bot sends the user two things: the webhook url and the validation token

2. The user will then paste these into their project creating a Keybase GitLab webhook

Things removed:

- The entire OAuth flow

- All API calls made from the app