### PR TITLE
githubbot: more specific author fetching

### DIFF
--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/keybase/managed-bots/base/git"
 
@@ -48,13 +49,13 @@ func (h *HTTPSrv) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
 func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	payload, err := github.ValidatePayload(r, []byte(h.secret))
 	if err != nil {
-		h.Errorf("Error validating payload: %s\n", err)
+		h.Debug("Error validating payload (%s): %s\n", r.Header.Get("X-GitHub-Delivery"), err)
 		return
 	}
 
 	event, err := github.ParseWebHook(github.WebHookType(r), payload)
 	if err != nil {
-		h.Errorf("could not parse webhook: %s\n", err)
+		h.Debug("could not parse webhook: %s\n", err)
 		return
 	}
 
@@ -74,7 +75,7 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 			repo = evt.GetRepo().GetFullName()
 			installationID = evt.GetInstallation().GetID()
 		} else {
-			h.Errorf("could not get information from webhook, webhook type: %s\n", github.WebHookType(r))
+			h.Debug("could not get information from webhook, webhook type: %s\n", github.WebHookType(r))
 			return
 		}
 	}
@@ -136,10 +137,16 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *HTTPSrv) formatMessage(event interface{}, repo string, defaultBranch string, client *github.Client) (message string, branch string) {
+	parsedRepo := strings.Split(repo, "/")
+	if len(parsedRepo) != 2 {
+		h.Debug("invalid repo: %s", repo)
+		return
+	}
+
 	branch = defaultBranch
 	switch event := event.(type) {
 	case *github.IssuesEvent:
-		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
+		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetIssue().GetUser().GetLogin())
 		message = git.FormatIssueMsg(
 			*event.Action,
 			author.String(),
@@ -153,7 +160,7 @@ func (h *HTTPSrv) formatMessage(event interface{}, repo string, defaultBranch st
 		if event.GetPullRequest().GetMerged() {
 			author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetPullRequest().GetMergedBy().GetLogin())
 		} else {
-			author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
+			author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetPullRequest().GetUser().GetLogin())
 		}
 
 		action := *event.Action
@@ -188,22 +195,32 @@ func (h *HTTPSrv) formatMessage(event interface{}, repo string, defaultBranch st
 			event.GetCompare())
 
 	case *github.CheckRunEvent:
-		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
 		if len(event.GetCheckRun().PullRequests) == 0 {
 			// this is a branch test, not associated with a PR
 			branch = event.GetCheckRun().GetCheckSuite().GetHeadBranch()
 		}
 		// if we're parsing a pr, use the default branch
+
+		// fetch the pull request object
+		pr, _, err := client.PullRequests.Get(context.TODO(), parsedRepo[0], parsedRepo[1], event.GetCheckRun().PullRequests[0].GetNumber())
+		if err != nil {
+			h.Errorf("Error getting pull request object: %s", err)
+			message = formatCheckRunMessage(event, "")
+			break
+		}
+		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, pr.GetUser().GetLogin())
 		message = formatCheckRunMessage(event, author.String())
 	case *github.StatusEvent:
-		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin())
+		var author username
 		pullRequests, _, err := client.PullRequests.ListPullRequestsWithCommit(
 			context.TODO(),
 			event.GetRepo().GetOwner().GetLogin(),
 			event.GetRepo().GetName(),
 			event.GetSHA(),
 			&github.PullRequestListOptions{
-				State: "open",
+				State:     "open",
+				Sort:      "updated",
+				Direction: "desc",
 			},
 		)
 		if err != nil {
@@ -212,7 +229,10 @@ func (h *HTTPSrv) formatMessage(event interface{}, repo string, defaultBranch st
 		if len(pullRequests) == 0 && len(event.Branches) >= 1 {
 			// this is a branch test, not associated with a PR
 			branch = event.Branches[0].GetName()
+			author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetCommit().GetAuthor().GetLogin())
 		}
+
+		author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, pullRequests[0].GetUser().GetLogin())
 		message = formatStatusMessage(event, pullRequests, author.String())
 
 	}

--- a/githubbot/githubbot/util.go
+++ b/githubbot/githubbot/util.go
@@ -67,12 +67,13 @@ func formatCheckRunMessage(evt *github.CheckRunEvent, username string) (res stri
 				res = fmt.Sprintf(":warning: %s cancelled for pull request #%d on %s.\n%s/pull/%d", testName, pr.GetNumber(), repo, evt.GetRepo().GetHTMLURL(), pr.GetNumber())
 			}
 		}
+
 		if isPullRequest && res != "" && username != "" {
-			if strings.HasPrefix(username, "@") {
-				res = fmt.Sprintf("%s\n%s", res, username)
-			} else {
-				res = fmt.Sprintf("%s\n(for %s)", res, username)
+			if strings.HasPrefix(username, "@") { // if keybase user, @ them directly
+				return fmt.Sprintf("%s\n%s", res, username)
 			}
+
+			return fmt.Sprintf("%s\n(for %s)", res, username)
 		}
 	}
 	return res
@@ -119,12 +120,13 @@ func formatStatusMessage(evt *github.StatusEvent, pullRequests []*github.PullReq
 			res = fmt.Sprintf(":x: %s failed for pull request #%d on %s.\n%s", testName, pr.GetNumber(), repo, targetURL)
 		}
 	}
+
 	if isPullRequest && res != "" && username != "" {
 		if strings.HasPrefix(username, "@") {
-			res = fmt.Sprintf("%s\n%s", res, username)
-		} else {
-			res = fmt.Sprintf("%s\n(for %s)", res, username)
+			return fmt.Sprintf("%s\n%s", res, username)
 		}
+
+		return fmt.Sprintf("%s\n(for %s)", res, username)
 	}
 	return res
 }

--- a/githubbot/githubbot/util.go
+++ b/githubbot/githubbot/util.go
@@ -67,8 +67,12 @@ func formatCheckRunMessage(evt *github.CheckRunEvent, username string) (res stri
 				res = fmt.Sprintf(":warning: %s cancelled for pull request #%d on %s.\n%s/pull/%d", testName, pr.GetNumber(), repo, evt.GetRepo().GetHTMLURL(), pr.GetNumber())
 			}
 		}
-		if strings.HasPrefix(username, "@") && isPullRequest && res != "" {
-			res = fmt.Sprintf("%s\n%s", res, username)
+		if isPullRequest && res != "" && username != "" {
+			if strings.HasPrefix(username, "@") {
+				res = fmt.Sprintf("%s\n%s", res, username)
+			} else {
+				res = fmt.Sprintf("%s\n(for %s)", res, username)
+			}
 		}
 	}
 	return res
@@ -115,8 +119,12 @@ func formatStatusMessage(evt *github.StatusEvent, pullRequests []*github.PullReq
 			res = fmt.Sprintf(":x: %s failed for pull request #%d on %s.\n%s", testName, pr.GetNumber(), repo, targetURL)
 		}
 	}
-	if strings.HasPrefix(username, "@") && isPullRequest && res != "" {
-		res = fmt.Sprintf("%s\n%s", res, username)
+	if isPullRequest && res != "" && username != "" {
+		if strings.HasPrefix(username, "@") {
+			res = fmt.Sprintf("%s\n%s", res, username)
+		} else {
+			res = fmt.Sprintf("%s\n(for %s)", res, username)
+		}
 	}
 	return res
 }


### PR DESCRIPTION
Turns out the `Sender` user in GitHub events basically means nothing for CI events and some others, so this PR changes the author fetching to be a little more specific (and uses some API calls to get information when the webhook isn't detailed enough on its own). Also references the github username that caused a CI event if they don't have mentions enabled, and moves some noisier errors to `Debug` instead of erroring.