### PR TITLE
gcalbot reminders

### DIFF
--- a/gcalbot/db.sql
+++ b/gcalbot/db.sql
@@ -40,10 +40,12 @@ CREATE TABLE `channel` (
 DROP TABLE IF EXISTS `subscription`;
 
 CREATE TABLE `subscription` (
-    `account_id` varchar(128) NOT NULL,         -- id for kb & google account (references account table)
-    `calendar_id` varchar(128) NOT NULL,        -- google calendar id that this subscription is for
-    `type` ENUM ('invite'),                     -- type of subscription
-    PRIMARY KEY (`account_id`, `calendar_id`),
+    `account_id` varchar(128) NOT NULL,             -- id for kb & google account (references account table)
+    `calendar_id` varchar(128) NOT NULL,            -- google calendar id that this subscription is for
+    `keybase_channel` varchar(128) NOT NULL,        -- channel that is subscribed to notifications
+    `minutes_before` int(11) NOT NULL DEFAULT 0,    -- minutes until event that a notification should be sent (for reminder)
+    `type` ENUM ('invite', 'reminder'),             -- type of subscription
+    PRIMARY KEY (`account_id`, `calendar_id`, `keybase_channel`, `minutes_before`, `type`),
     FOREIGN KEY (`account_id`) REFERENCES account(`account_id`),
     FOREIGN KEY (`account_id`, `calendar_id`) REFERENCES channel(`account_id`, `calendar_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/gcalbot/db.sql
+++ b/gcalbot/db.sql
@@ -42,10 +42,10 @@ DROP TABLE IF EXISTS `subscription`;
 CREATE TABLE `subscription` (
     `account_id` varchar(128) NOT NULL,             -- id for kb & google account (references account table)
     `calendar_id` varchar(128) NOT NULL,            -- google calendar id that this subscription is for
-    `keybase_channel` varchar(128) NOT NULL,        -- channel that is subscribed to notifications
+    `keybase_conv_id` varchar(128) NOT NULL,        -- channel that is subscribed to notifications
     `minutes_before` int(11) NOT NULL DEFAULT 0,    -- minutes until event that a notification should be sent (for reminder)
     `type` ENUM ('invite', 'reminder'),             -- type of subscription
-    PRIMARY KEY (`account_id`, `calendar_id`, `keybase_channel`, `minutes_before`, `type`),
+    PRIMARY KEY (`account_id`, `calendar_id`, `keybase_conv_id`, `minutes_before`, `type`),
     FOREIGN KEY (`account_id`) REFERENCES account(`account_id`),
     FOREIGN KEY (`account_id`, `calendar_id`) REFERENCES channel(`account_id`, `calendar_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/gcalbot/gcalbot/account.go
+++ b/gcalbot/gcalbot/account.go
@@ -49,7 +49,7 @@ func (h *Handler) HandleAuth(msg chat1.MsgSummary, accountID string) (err error)
 	return nil
 }
 
-func (h *Handler) accountsListHandler(msg chat1.MsgSummary) error {
+func (h *Handler) handleAccountsList(msg chat1.MsgSummary) error {
 	username := msg.Sender.Username
 	accounts, err := h.db.GetAccountNicknameListForUsername(username)
 	if err != nil {
@@ -71,7 +71,7 @@ func (h *Handler) accountsListHandler(msg chat1.MsgSummary) error {
 	return nil
 }
 
-func (h *Handler) accountsConnectHandler(msg chat1.MsgSummary, args []string) error {
+func (h *Handler) handleAccountsConnect(msg chat1.MsgSummary, args []string) error {
 	if len(args) != 1 {
 		h.ChatEcho(msg.ConvID, "Invalid number of arguments.")
 		return nil
@@ -106,7 +106,7 @@ func (h *Handler) accountsConnectHandler(msg chat1.MsgSummary, args []string) er
 	return nil
 }
 
-func (h *Handler) accountsDisconnectHandler(msg chat1.MsgSummary, args []string) error {
+func (h *Handler) handleAccountsDisconnect(msg chat1.MsgSummary, args []string) error {
 	if len(args) != 1 {
 		h.ChatEcho(msg.ConvID, "Invalid number of arguments.")
 		return nil

--- a/gcalbot/gcalbot/calendar.go
+++ b/gcalbot/gcalbot/calendar.go
@@ -11,7 +11,7 @@ import (
 	"github.com/keybase/managed-bots/base"
 )
 
-func (h *Handler) handleListCalendars(msg chat1.MsgSummary, args []string) error {
+func (h *Handler) handleCalendarsList(msg chat1.MsgSummary, args []string) error {
 	if len(args) != 1 {
 		h.ChatEcho(msg.ConvID, "Invalid number of arguments.")
 		return nil

--- a/gcalbot/gcalbot/db.go
+++ b/gcalbot/gcalbot/db.go
@@ -353,12 +353,14 @@ func (d *DB) GetAggregatedReminderSubscriptions() (reminders []*AggregatedRemind
 			return nil, err
 		}
 		// parse MinutesBefore from GROUP_CONCAT bytes
-		for _, minutesBeforeItem := range strings.Split(string(minutesBeforeBytes), ",") {
+		minutesBeforeStrings := strings.Split(string(minutesBeforeBytes), ",")
+		reminder.MinutesBefore = make([]int, len(minutesBeforeStrings))
+		for index, minutesBeforeItem := range minutesBeforeStrings {
 			minutesBefore, err := strconv.Atoi(minutesBeforeItem)
 			if err != nil {
 				return nil, err
 			}
-			reminder.MinutesBefore = append(reminder.MinutesBefore, minutesBefore)
+			reminder.MinutesBefore[index] = minutesBefore
 		}
 		reminder.Account.AccountID = reminder.AccountID
 		reminder.Token.Expiry = time.Unix(expiry, 0)

--- a/gcalbot/gcalbot/event.go
+++ b/gcalbot/gcalbot/event.go
@@ -1,0 +1,73 @@
+package gcalbot
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/calendar/v3"
+)
+
+func FormatEvent(
+	event *calendar.Event,
+	accountNickname, calendarSummary, timezone string,
+	format24HourTime bool,
+) (string, error) {
+	message := `%s
+> What: *%s*
+> When: %s%s%s%s%s
+> Calendar: %s`
+
+	// strip protocol to skip unfurl prompt
+	url := strings.TrimPrefix(event.HtmlLink, "https://")
+
+	what := event.Summary
+
+	// TODO(marcel): better date formatting for recurring events
+	when, err := FormatTimeRange(event.Start, event.End, timezone, format24HourTime)
+	if err != nil {
+		return "", err
+	}
+
+	var where string
+	if event.Location != "" {
+		where = fmt.Sprintf("\n> Where: %s", event.Location)
+	}
+
+	var organizer string
+	if event.Organizer.DisplayName != "" && event.Organizer.Email != "" {
+		organizer = fmt.Sprintf("\n> Organizer: %s <%s>", event.Organizer.DisplayName, event.Organizer.Email)
+	} else if event.Organizer.DisplayName != "" {
+		organizer = fmt.Sprintf("\n> Organizer: %s", event.Organizer.DisplayName)
+	} else if event.Organizer.Email != "" {
+		organizer = fmt.Sprintf("\n> Organizer: %s", event.Organizer.Email)
+	}
+
+	var conferenceData string
+	if event.ConferenceData != nil {
+		for _, entryPoint := range event.ConferenceData.EntryPoints {
+			uri := strings.TrimPrefix(entryPoint.Uri, "https://")
+			switch entryPoint.EntryPointType {
+			case "video", "more":
+				conferenceData += fmt.Sprintf("\n> Join online: %s", uri)
+			case "phone":
+				conferenceData += fmt.Sprintf("\n> Join by phone: %s", entryPoint.Label)
+				if entryPoint.Pin != "" {
+					conferenceData += fmt.Sprintf(" PIN: %s", entryPoint.Pin)
+				}
+			case "sip":
+				conferenceData += fmt.Sprintf("\n> Join by SIP: %s", entryPoint.Label)
+			}
+		}
+	}
+
+	// note: description can contain HTML
+	var description string
+	if event.Description != "" {
+		description = fmt.Sprintf("\n> Description: %s", event.Description)
+	}
+
+	accountCalendar := fmt.Sprintf("%s [%s]", calendarSummary, accountNickname)
+
+	return fmt.Sprintf(message,
+		url, what, when, where, conferenceData, organizer, description, accountCalendar), nil
+}

--- a/gcalbot/gcalbot/event.go
+++ b/gcalbot/gcalbot/event.go
@@ -3,13 +3,15 @@ package gcalbot
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"google.golang.org/api/calendar/v3"
 )
 
 func FormatEvent(
 	event *calendar.Event,
-	accountNickname, calendarSummary, timezone string,
+	accountNickname, calendarSummary string,
+	timezone *time.Location,
 	format24HourTime bool,
 ) (string, error) {
 	message := `%s

--- a/gcalbot/gcalbot/handler.go
+++ b/gcalbot/gcalbot/handler.go
@@ -80,6 +80,12 @@ func (h *Handler) HandleCommand(msg chat1.MsgSummary) error {
 		return h.handleInvitesSubscribe(msg, tokens[3:])
 	case strings.HasPrefix(cmd, "!gcal invites unsubscribe"):
 		return h.handleInvitesUnsubscribe(msg, tokens[3:])
+	case strings.HasPrefix(cmd, "!gcal reminders subscribe"):
+		return h.handleRemindersSubscribe(msg, tokens[3:])
+	case strings.HasPrefix(cmd, "!gcal reminders unsubscribe"):
+		return h.handleRemindersUnsubscribe(msg, tokens[3:])
+	case strings.HasPrefix(cmd, "!gcal reminders list"):
+		return h.handleRemindersList(msg, tokens[3:])
 	default:
 		h.ChatEcho(msg.ConvID, "Unknown command.")
 		return nil

--- a/gcalbot/gcalbot/handler.go
+++ b/gcalbot/gcalbot/handler.go
@@ -69,17 +69,17 @@ func (h *Handler) HandleCommand(msg chat1.MsgSummary) error {
 
 	switch {
 	case strings.HasPrefix(cmd, "!gcal accounts list"):
-		return h.accountsListHandler(msg)
+		return h.handleAccountsList(msg)
 	case strings.HasPrefix(cmd, "!gcal accounts connect"):
-		return h.accountsConnectHandler(msg, tokens[3:])
+		return h.handleAccountsConnect(msg, tokens[3:])
 	case strings.HasPrefix(cmd, "!gcal accounts disconnect"):
-		return h.accountsDisconnectHandler(msg, tokens[3:])
-	case strings.HasPrefix(cmd, "!gcal list-calendars"):
-		return h.handleListCalendars(msg, tokens[2:])
-	case strings.HasPrefix(cmd, "!gcal subscribe invites"):
-		return h.handleSubscribeInvites(msg, tokens[3:])
-	case strings.HasPrefix(cmd, "!gcal unsubscribe invites"):
-		return h.handleUnsubscribeInvites(msg, tokens[3:])
+		return h.handleAccountsDisconnect(msg, tokens[3:])
+	case strings.HasPrefix(cmd, "!gcal calendars list"):
+		return h.handleCalendarsList(msg, tokens[3:])
+	case strings.HasPrefix(cmd, "!gcal invites subscribe"):
+		return h.handleInvitesSubscribe(msg, tokens[3:])
+	case strings.HasPrefix(cmd, "!gcal invites unsubscribe"):
+		return h.handleInvitesUnsubscribe(msg, tokens[3:])
 	default:
 		h.ChatEcho(msg.ConvID, "Unknown command.")
 		return nil

--- a/gcalbot/gcalbot/invite.go
+++ b/gcalbot/gcalbot/invite.go
@@ -63,7 +63,6 @@ func (h *Handler) handleInvitesSubscribe(msg chat1.MsgSummary, args []string) er
 		AccountID:     accountID,
 		CalendarID:    primaryCalendar.Id,
 		KeybaseConvID: msg.ConvID,
-		MinutesBefore: 0,
 		Type:          SubscriptionTypeInvite,
 	})
 	if err != nil || exists {
@@ -112,7 +111,6 @@ func (h *Handler) handleInvitesUnsubscribe(msg chat1.MsgSummary, args []string) 
 		AccountID:     accountID,
 		CalendarID:    primaryCalendar.Id,
 		KeybaseConvID: msg.ConvID,
-		MinutesBefore: 0,
 		Type:          SubscriptionTypeInvite,
 	})
 	if err != nil || !exists {

--- a/gcalbot/gcalbot/invite.go
+++ b/gcalbot/gcalbot/invite.go
@@ -3,7 +3,6 @@ package gcalbot
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/keybase/go-keybase-chat-bot/kbchat/types/chat1"
 	"github.com/keybase/managed-bots/base"
@@ -137,15 +136,11 @@ Awaiting your response. *Are you going?*`
 		eventType = "a recurring event"
 	}
 
-	timezone, err := srv.Settings.Get("timezone").Do()
+	timezone, err := GetUserTimezone(srv)
 	if err != nil {
 		return err
 	}
-	format24HourTimeSetting, err := srv.Settings.Get("format24HourTime").Do()
-	if err != nil {
-		return err
-	}
-	format24HourTime, err := strconv.ParseBool(format24HourTimeSetting.Value)
+	format24HourTime, err := GetUserFormat24HourTime(srv)
 	if err != nil {
 		return err
 	}
@@ -157,7 +152,7 @@ Awaiting your response. *Are you going?*`
 	if err != nil {
 		return err
 	}
-	eventContent, err := FormatEvent(event, account.AccountNickname, invitedCalendar.Summary, timezone.Value, format24HourTime)
+	eventContent, err := FormatEvent(event, account.AccountNickname, invitedCalendar.Summary, timezone, format24HourTime)
 	if err != nil {
 		return err
 	}

--- a/gcalbot/gcalbot/invite.go
+++ b/gcalbot/gcalbot/invite.go
@@ -31,7 +31,7 @@ const (
 	ResponseStatusAccepted    ResponseStatus = "accepted"
 )
 
-func (h *Handler) handleSubscribeInvites(msg chat1.MsgSummary, args []string) error {
+func (h *Handler) handleInvitesSubscribe(msg chat1.MsgSummary, args []string) error {
 	if !base.IsDirectPrivateMessage(h.kbc.GetUsername(), msg) {
 		h.ChatEcho(msg.ConvID, "This command can only be run through direct message.")
 		return nil
@@ -90,7 +90,7 @@ func (h *Handler) handleSubscribeInvites(msg chat1.MsgSummary, args []string) er
 	return nil
 }
 
-func (h *Handler) handleUnsubscribeInvites(msg chat1.MsgSummary, args []string) error {
+func (h *Handler) handleInvitesUnsubscribe(msg chat1.MsgSummary, args []string) error {
 	if !base.IsDirectPrivateMessage(h.kbc.GetUsername(), msg) {
 		h.ChatEcho(msg.ConvID, "This command can only be run through direct message.")
 		return nil

--- a/gcalbot/gcalbot/reminder.go
+++ b/gcalbot/gcalbot/reminder.go
@@ -1,0 +1,107 @@
+package gcalbot
+
+import (
+	"context"
+
+	"github.com/keybase/managed-bots/base"
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/option"
+
+	"github.com/keybase/go-keybase-chat-bot/kbchat/types/chat1"
+)
+
+func (h *Handler) handleRemindersSubscribe(msg chat1.MsgSummary, args []string) error {
+	if len(args) != 3 {
+		h.ChatEcho(msg.ConvID, "Invalid number of arguments.")
+		return nil
+	}
+
+	keybaseUsername := msg.Sender.Username
+	accountNickname := args[0]
+	accountID := GetAccountID(keybaseUsername, accountNickname)
+
+	client, err := base.GetOAuthClient(accountID, msg, h.kbc, h.requests, h.config, h.db,
+		h.getAccountOAuthOpts(msg, accountNickname))
+	if err != nil || client == nil {
+		// if no error, account doesn't exist, short circuit
+		return err
+	}
+
+	srv, err := calendar.NewService(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+		return err
+	}
+
+	duration, userErr, err := ParseReminderDuration(args[1], args[2])
+	if err != nil {
+		return err
+	} else if userErr != "" {
+		h.ChatEcho(msg.ConvID, userErr)
+		return nil
+	}
+
+	primaryCalendar, err := getPrimaryCalendar(srv)
+	if err != nil {
+		return err
+	}
+
+	h.ChatEcho(msg.ConvID, "OK, you will be reminded of events %s before they happen for your primary calendar '%s'.",
+		duration, primaryCalendar.Id)
+
+	return nil
+}
+
+func (h *Handler) handleRemindersUnsubscribe(msg chat1.MsgSummary, args []string) error {
+	if len(args) != 3 {
+		h.ChatEcho(msg.ConvID, "Invalid number of arguments.")
+		return nil
+	}
+
+	keybaseUsername := msg.Sender.Username
+	accountNickname := args[0]
+	accountID := GetAccountID(keybaseUsername, accountNickname)
+
+	token, err := h.db.GetToken(accountID)
+	if err != nil || token == nil {
+		// if no error, account doesn't exist, short circuit
+		return err
+	}
+
+	client := h.config.Client(context.Background(), token)
+	srv, err := calendar.NewService(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+		return err
+	}
+
+	duration, userErr, err := ParseReminderDuration(args[1], args[2])
+	if err != nil {
+		return err
+	} else if userErr != "" {
+		h.ChatEcho(msg.ConvID, userErr)
+		return nil
+	}
+
+	primaryCalendar, err := getPrimaryCalendar(srv)
+	if err != nil {
+		return err
+	}
+
+	h.ChatEcho(msg.ConvID, "OK, you will no longer be reminded of events %s before they happen for your primary calendar '%s'.", duration, primaryCalendar.Id)
+
+	return nil
+}
+
+func (h *Handler) handleRemindersList(msg chat1.MsgSummary, args []string) error {
+	if len(args) != 1 {
+		h.ChatEcho(msg.ConvID, "Invalid number of arguments.")
+		return nil
+	}
+
+	// keybaseUsername := msg.Sender.Username
+	accountNickname := args[0]
+	// accountID := GetAccountID(keybaseUsername, accountNickname)
+
+	h.ChatEcho(msg.ConvID, "There are no calendars associated with the account '%s'.", accountNickname)
+
+	return nil
+}

--- a/gcalbot/gcalbot/reminder.go
+++ b/gcalbot/gcalbot/reminder.go
@@ -48,11 +48,11 @@ func (h *Handler) handleRemindersSubscribe(msg chat1.MsgSummary, args []string) 
 	}
 
 	exists, err := h.createSubscription(srv, Subscription{
-		AccountID:     accountID,
-		CalendarID:    primaryCalendar.Id,
-		KeybaseConvID: msg.ConvID,
-		MinutesBefore: minutesBefore,
-		Type:          SubscriptionTypeReminder,
+		AccountID:      accountID,
+		CalendarID:     primaryCalendar.Id,
+		KeybaseConvID:  msg.ConvID,
+		DurationBefore: GetDurationFromMinutes(minutesBefore),
+		Type:           SubscriptionTypeReminder,
 	})
 	if err != nil || exists {
 		// if no error, subscription exists, short circuit
@@ -101,11 +101,11 @@ func (h *Handler) handleRemindersUnsubscribe(msg chat1.MsgSummary, args []string
 	}
 
 	exists, err := h.removeSubscription(srv, Subscription{
-		AccountID:     accountID,
-		CalendarID:    primaryCalendar.Id,
-		KeybaseConvID: msg.ConvID,
-		MinutesBefore: minutesBefore,
-		Type:          SubscriptionTypeReminder,
+		AccountID:      accountID,
+		CalendarID:     primaryCalendar.Id,
+		KeybaseConvID:  msg.ConvID,
+		DurationBefore: GetDurationFromMinutes(minutesBefore),
+		Type:           SubscriptionTypeReminder,
 	})
 	if err != nil || !exists {
 		// if no error, subscription doesn't exist, short circuit
@@ -145,7 +145,7 @@ func (h *Handler) handleRemindersList(msg chat1.MsgSummary, args []string) error
 		return err
 	}
 
-	minutesBeforeList, err := h.db.GetReminderMinutesBeforeList(accountID, primaryCalendar.Id, msg.ConvID)
+	minutesBeforeList, err := h.db.GetReminderDurationBeforeList(accountID, primaryCalendar.Id, msg.ConvID)
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func (h *Handler) handleRemindersList(msg chat1.MsgSummary, args []string) error
 
 	data := []interface{}{primaryCalendar.Summary, accountNickname}
 	for _, minutesBefore := range minutesBeforeList {
-		data = append(data, MinutesBeforeString(minutesBefore))
+		data = append(data, MinutesBeforeString(GetMinutesFromDuration(minutesBefore)))
 	}
 
 	calendarListMessage := "Here are the reminders associated with calendar '%s' for account '%s':" +

--- a/gcalbot/gcalbot/reminder.go
+++ b/gcalbot/gcalbot/reminder.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/keybase/managed-bots/base"
 	"google.golang.org/api/calendar/v3"
@@ -44,6 +49,18 @@ func (h *Handler) handleRemindersSubscribe(msg chat1.MsgSummary, args []string) 
 
 	primaryCalendar, err := getPrimaryCalendar(srv)
 	if err != nil {
+		return err
+	}
+
+	exists, err := h.createSubscription(srv, Subscription{
+		AccountID:      accountID,
+		CalendarID:     primaryCalendar.Id,
+		KeybaseChannel: keybaseUsername,
+		MinutesBefore:  minutesBefore,
+		Type:           SubscriptionTypeReminder,
+	})
+	if err != nil || exists {
+		// if no error, subscription exists, short circuit
 		return err
 	}
 
@@ -88,6 +105,18 @@ func (h *Handler) handleRemindersUnsubscribe(msg chat1.MsgSummary, args []string
 		return err
 	}
 
+	exists, err := h.removeSubscription(srv, Subscription{
+		AccountID:      accountID,
+		CalendarID:     primaryCalendar.Id,
+		KeybaseChannel: keybaseUsername,
+		MinutesBefore:  minutesBefore,
+		Type:           SubscriptionTypeReminder,
+	})
+	if err != nil || !exists {
+		// if no error, subscription doesn't exist, short circuit
+		return err
+	}
+
 	h.ChatEcho(msg.ConvID, "OK, you will no longer be reminded of events %s before they happen for your primary calendar '%s'.",
 		minutesBeforeString(minutesBefore), primaryCalendar.Id)
 
@@ -100,11 +129,46 @@ func (h *Handler) handleRemindersList(msg chat1.MsgSummary, args []string) error
 		return nil
 	}
 
-	// keybaseUsername := msg.Sender.Username
+	keybaseUsername := msg.Sender.Username
 	accountNickname := args[0]
-	// accountID := GetAccountID(keybaseUsername, accountNickname)
+	accountID := GetAccountID(keybaseUsername, accountNickname)
 
-	h.ChatEcho(msg.ConvID, "There are no calendars associated with the account '%s'.", accountNickname)
+	token, err := h.db.GetToken(accountID)
+	if err != nil || token == nil {
+		// if no error, account doesn't exist, short circuit
+		return err
+	}
+
+	client := h.config.Client(context.Background(), token)
+	srv, err := calendar.NewService(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+		return err
+	}
+
+	primaryCalendar, err := getPrimaryCalendar(srv)
+	if err != nil {
+		return err
+	}
+
+	minutesBeforeList, err := h.db.GetReminderMinutesBeforeList(accountID, primaryCalendar.Id, keybaseUsername)
+	if err != nil {
+		return err
+	}
+
+	if len(minutesBeforeList) == 0 {
+		h.ChatEcho(msg.ConvID, "There are no reminders associated with calendar '%s' for account '%s'.",
+			primaryCalendar.Summary, accountNickname)
+		return nil
+	}
+
+	data := []interface{}{primaryCalendar.Summary, accountNickname}
+	for _, minutesBefore := range minutesBeforeList {
+		data = append(data, minutesBeforeString(minutesBefore))
+	}
+
+	calendarListMessage := "Here are the reminders associated with calendar '%s' for account '%s':" +
+		strings.Repeat("\n• %s before an event", len(minutesBeforeList))
+	h.ChatEcho(msg.ConvID, calendarListMessage, data...)
 
 	return nil
 }
@@ -138,5 +202,92 @@ func minutesBeforeString(minutesBefore int) string {
 		return "1 minute"
 	} else {
 		return fmt.Sprintf("%d minutes", minutesBefore)
+	}
+}
+
+type ReminderEvent struct {
+	EventID string
+}
+
+type Reminder struct {
+	Event         *ReminderEvent
+	MinutesBefore int
+}
+
+type ReminderScheduler struct {
+	*base.DebugOutput
+	sync.Mutex
+
+	shutdownCh chan struct{}
+
+	events    map[string]*ReminderEvent
+	reminders map[string][]Reminder
+}
+
+func NewReminderScheduler(
+	debugConfig *base.ChatDebugOutputConfig,
+) *ReminderScheduler {
+	return &ReminderScheduler{
+		DebugOutput: base.NewDebugOutput("ReminderScheduler", debugConfig),
+		shutdownCh:  make(chan struct{}),
+		events:      make(map[string]*ReminderEvent),
+		reminders:   make(map[string][]Reminder),
+	}
+}
+
+func (r *ReminderScheduler) Run() error {
+	r.Lock()
+	shutdownCh := r.shutdownCh
+	r.Unlock()
+	var eg errgroup.Group
+	eg.Go(func() error { return r.eventSyncLoop(shutdownCh) })
+	eg.Go(func() error { return r.sendReminderLoop(shutdownCh) })
+	if err := eg.Wait(); err != nil {
+		r.Debug("wait error: %s", err)
+		return err
+	}
+	r.Debug("shut down")
+	return nil
+}
+
+func (r *ReminderScheduler) Shutdown() error {
+	r.Lock()
+	defer r.Unlock()
+	if r.shutdownCh != nil {
+		close(r.shutdownCh)
+		r.shutdownCh = nil
+	}
+	return nil
+}
+
+func (r *ReminderScheduler) eventSyncLoop(shutdownCh chan struct{}) error {
+	ticker := time.NewTicker(time.Hour)
+	defer func() {
+		ticker.Stop()
+		r.Debug("shutting down eventSyncLoop")
+	}()
+	for {
+		select {
+		case <-shutdownCh:
+			return nil
+		case <-ticker.C:
+			// do something
+		}
+	}
+}
+
+func (r *ReminderScheduler) sendReminderLoop(shutdownCh chan struct{}) error {
+	ticker := time.NewTicker(time.Minute)
+	defer func() {
+		ticker.Stop()
+		r.Debug("shutting down sendReminderLoop")
+	}()
+	for {
+		select {
+		case <-shutdownCh:
+			return nil
+		case <-ticker.C:
+			// do something
+		}
 	}
 }

--- a/gcalbot/gcalbot/reminderscheduler/main.go
+++ b/gcalbot/gcalbot/reminderscheduler/main.go
@@ -1,0 +1,61 @@
+package reminderscheduler
+
+import (
+	"sync"
+
+	"github.com/keybase/managed-bots/base"
+	"github.com/keybase/managed-bots/gcalbot/gcalbot"
+	"golang.org/x/oauth2"
+	"golang.org/x/sync/errgroup"
+)
+
+type ReminderScheduler struct {
+	*base.DebugOutput
+	sync.Mutex
+
+	shutdownCh chan struct{}
+
+	db     *gcalbot.DB
+	config *oauth2.Config
+
+	eventMap         ReminderEventMap
+	reminderSchedule ReminderSchedule
+}
+
+func NewReminderScheduler(
+	debugConfig *base.ChatDebugOutputConfig,
+	db *gcalbot.DB,
+	config *oauth2.Config,
+) *ReminderScheduler {
+	return &ReminderScheduler{
+		DebugOutput: base.NewDebugOutput("ReminderScheduler", debugConfig),
+		shutdownCh:  make(chan struct{}),
+		db:          db,
+		config:      config,
+	}
+}
+
+func (r *ReminderScheduler) Run() error {
+	r.Lock()
+	shutdownCh := r.shutdownCh
+	r.Unlock()
+	var eg errgroup.Group
+	eg.Go(func() error { return r.eventSyncLoop(shutdownCh) })
+	eg.Go(func() error { return r.sendReminderLoop(shutdownCh) })
+	if err := eg.Wait(); err != nil {
+		r.Debug("wait error: %s", err)
+		return err
+	}
+	r.Debug("shut down")
+	return nil
+}
+
+func (r *ReminderScheduler) Shutdown() error {
+	r.Lock()
+	defer r.Unlock()
+	if r.shutdownCh != nil {
+		close(r.shutdownCh)
+		r.shutdownCh = nil
+	}
+	return nil
+}

--- a/gcalbot/gcalbot/reminderscheduler/send.go
+++ b/gcalbot/gcalbot/reminderscheduler/send.go
@@ -39,11 +39,12 @@ func (r *ReminderScheduler) sendReminders(sendMinute time.Time) {
 		for _, subscription := range event.Subscriptions {
 			if subscription.Timestamp == timestamp {
 				// TODO(marcel): check if the user still has this reminder set
-				if subscription.MinutesBefore == 0 {
+				minutesBefore := gcalbot.GetMinutesFromDuration(subscription.DurationBefore)
+				if minutesBefore == 0 {
 					r.ChatEcho(subscription.KeybaseConvID, "An event is starting now: %s", event.MsgContent)
 				} else {
 					r.ChatEcho(subscription.KeybaseConvID, "An event is starting in %s: %s",
-						gcalbot.MinutesBeforeString(subscription.MinutesBefore), event.MsgContent)
+						gcalbot.MinutesBeforeString(minutesBefore), event.MsgContent)
 				}
 			}
 		}

--- a/gcalbot/gcalbot/reminderscheduler/send.go
+++ b/gcalbot/gcalbot/reminderscheduler/send.go
@@ -1,0 +1,70 @@
+package reminderscheduler
+
+import (
+	"time"
+
+	"github.com/keybase/managed-bots/gcalbot/gcalbot"
+)
+
+// reference: https://stackoverflow.com/a/39295990
+type ReminderTicker struct {
+	*time.Timer
+}
+
+func NewReminderTicker() *ReminderTicker {
+	return &ReminderTicker{time.NewTimer(getNextTickDuration())}
+}
+
+func (rt *ReminderTicker) Update() {
+	rt.Reset(getNextTickDuration())
+}
+
+func getNextTickDuration() time.Duration {
+	now := time.Now()
+	// the next tick is the following minute from now
+	nextTick := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute()+1, 0, 0, time.Local)
+	return nextTick.Sub(now)
+}
+
+func (r *ReminderScheduler) sendReminderLoop(shutdownCh chan struct{}) error {
+	ticker := NewReminderTicker()
+	defer func() {
+		ticker.Stop()
+		r.Debug("shutting down sendReminderLoop")
+	}()
+	for {
+		select {
+		case <-shutdownCh:
+			return nil
+		case sendMinute := <-ticker.C:
+			r.sendReminders(sendMinute)
+			sendDuration := time.Since(sendMinute)
+			if sendDuration.Seconds() > 15 {
+				r.Errorf("sending reminders took %s", sendDuration.String())
+			}
+			ticker.Update()
+		}
+	}
+}
+
+func (r *ReminderScheduler) sendReminders(sendMinute time.Time) {
+	timestamp := getReminderTimestamp(sendMinute, 0)
+	r.reminderSchedule.ForEachReminderInMinute(timestamp, func(event *ReminderEvent, remove func()) {
+		event.Lock()
+		defer event.Unlock()
+		for _, subscription := range event.Subscriptions {
+			if subscription.Timestamp == timestamp {
+				// TODO(marcel): check if the user still has this reminder set
+				if subscription.MinutesBefore == 0 {
+					r.ChatEcho(subscription.KeybaseConvID, "An event is starting now: %s", event.MsgContent)
+				} else {
+					r.ChatEcho(subscription.KeybaseConvID, "An event is starting in %s: %s",
+						gcalbot.MinutesBeforeString(subscription.MinutesBefore), event.MsgContent)
+				}
+			}
+		}
+		remove()
+		// TODO(marcel): remove event if this was the last reminder
+	})
+	r.reminderSchedule.Delete(timestamp)
+}

--- a/gcalbot/gcalbot/reminderscheduler/sync.go
+++ b/gcalbot/gcalbot/reminderscheduler/sync.go
@@ -131,7 +131,7 @@ func (r *ReminderScheduler) updateOrCreateReminderEvent(
 					}
 				})
 				// add new reminder
-				newTimestamp := getReminderTimestamp(newStartTime, subscription.MinutesBefore)
+				newTimestamp := getReminderTimestamp(newStartTime, subscription.DurationBefore)
 				r.reminderSchedule.AddReminderToMinute(newTimestamp, reminderEvent)
 				r.Debug("added reminder for '%s', cal '%s' at %s", event.Summary, subscribedCalendar.Summary, newTimestamp)
 				// update subscription
@@ -142,15 +142,15 @@ func (r *ReminderScheduler) updateOrCreateReminderEvent(
 		reminderEvent.MsgContent = eventMsgContent
 	} else {
 		r.eventMap.Set(event.Id, reminderEvent)
-		for _, minutesBefore := range subscriptionSet.MinutesBefore {
-			if newStartTime.Add(-time.Duration(minutesBefore) * time.Minute).Before(time.Now()) {
+		for _, durationBefore := range subscriptionSet.DurationBefore {
+			if newStartTime.Add(-durationBefore).Before(time.Now()) {
 				continue
 			}
-			timestamp := getReminderTimestamp(newStartTime, minutesBefore)
+			timestamp := getReminderTimestamp(newStartTime, durationBefore)
 			reminderEvent.Subscriptions = append(reminderEvent.Subscriptions, &ReminderEventSubscriptions{
-				KeybaseConvID: subscriptionSet.KeybaseConvID,
-				Timestamp:     timestamp,
-				MinutesBefore: minutesBefore,
+				KeybaseConvID:  subscriptionSet.KeybaseConvID,
+				Timestamp:      timestamp,
+				DurationBefore: durationBefore,
 			})
 			r.Debug("added reminder for '%s', cal '%s' at %s", event.Summary, subscribedCalendar.Summary, timestamp)
 			r.reminderSchedule.AddReminderToMinute(timestamp, reminderEvent)

--- a/gcalbot/gcalbot/reminderscheduler/sync.go
+++ b/gcalbot/gcalbot/reminderscheduler/sync.go
@@ -1,0 +1,164 @@
+package reminderscheduler
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/keybase/managed-bots/gcalbot/gcalbot"
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/option"
+)
+
+func (r *ReminderScheduler) eventSyncLoop(shutdownCh chan struct{}) error {
+	ticker := time.NewTicker(time.Hour)
+	defer func() {
+		ticker.Stop()
+		r.Debug("shutting down eventSyncLoop")
+	}()
+
+	eventSync := func() {
+		subscriptions, err := r.db.GetAggregatedReminderSubscriptions()
+		if err != nil {
+			r.Errorf("error getting reminder subscriptions to sync: %s", err)
+		}
+		for _, subscription := range subscriptions {
+			select {
+			case <-shutdownCh:
+				return
+			default:
+			}
+
+			client := r.config.Client(context.Background(), subscription.Token)
+			srv, err := calendar.NewService(context.Background(), option.WithHTTPClient(client))
+			if err != nil {
+				r.Errorf(err.Error())
+				continue
+			}
+
+			// sync 3 hours of events
+			minTime := time.Now().UTC()
+			maxTime := minTime.Add(3 * time.Hour)
+			var events []*calendar.Event
+			err = srv.Events.
+				List(subscription.CalendarID).
+				TimeMin(minTime.Format(time.RFC3339)).
+				TimeMax(maxTime.Format(time.RFC3339)).
+				Pages(context.Background(), func(page *calendar.Events) error {
+					events = append(events, page.Items...)
+					return nil
+				})
+			if err != nil {
+				r.Errorf("error getting events from API: %s", err)
+				continue
+			}
+			for _, event := range events {
+				err = r.updateOrCreateReminderEvent(srv, event, subscription)
+				if err != nil {
+					r.Errorf("error updating or creating reminder event: %s", err)
+				}
+			}
+		}
+	}
+
+	eventSync()
+	for {
+		select {
+		case <-shutdownCh:
+			return nil
+		case <-ticker.C:
+			eventSync()
+		}
+	}
+}
+
+func (r *ReminderScheduler) updateOrCreateReminderEvent(
+	srv *calendar.Service,
+	newCalEvent *calendar.Event,
+	subscriptionSet *gcalbot.AggregatedReminderSubscription,
+) error {
+	if newCalEvent.Start.DateTime == "" {
+		// TODO(marcel): notifications for all day events
+		return nil
+	}
+	newStartTime, err := time.Parse(time.RFC3339, newCalEvent.Start.DateTime)
+	if err != nil {
+		return fmt.Errorf("error parsing event start time: %s", err)
+	}
+
+	event, ok := r.eventMap.Get(newCalEvent.Id)
+
+	timezone, err := srv.Settings.Get("timezone").Do()
+	if err != nil {
+		return err
+	}
+	format24HourTimeSetting, err := srv.Settings.Get("format24HourTime").Do()
+	if err != nil {
+		return err
+	}
+	format24HourTime, err := strconv.ParseBool(format24HourTimeSetting.Value)
+	if err != nil {
+		return err
+	}
+	invitedCalendar, err := srv.Calendars.Get(subscriptionSet.CalendarID).Do()
+	if err != nil {
+		return err
+	}
+	eventMsgContent, err := gcalbot.FormatEvent(newCalEvent, subscriptionSet.Account.AccountNickname,
+		invitedCalendar.Summary, timezone.Value, format24HourTime)
+	if err != nil {
+		return err
+	}
+
+	if ok {
+		event.Lock()
+		defer event.Unlock()
+		if !newStartTime.Equal(event.StartTime) {
+			event.StartTime = newStartTime
+			for index, subscription := range event.Subscriptions {
+				// remove old reminder
+				r.reminderSchedule.ForEachReminderInMinute(subscription.Timestamp, func(reminderEvent *ReminderEvent, remove func()) {
+					reminderEvent.Lock()
+					defer reminderEvent.Unlock()
+					if event.EventID == reminderEvent.EventID {
+						remove()
+						r.Debug("removed reminder for %s at %s", newCalEvent.Id, subscription.Timestamp)
+					}
+				})
+				// add new reminder
+				newTimestamp := getReminderTimestamp(newStartTime, subscription.MinutesBefore)
+				r.reminderSchedule.AddReminderToMinute(newTimestamp, event)
+				r.Debug("added reminder for %s at %s", newCalEvent.Id, newTimestamp)
+				// update subscription
+				event.Subscriptions[index].Timestamp = newTimestamp
+				r.Debug("updated subscription for %s to", newCalEvent.Id, newTimestamp)
+			}
+		}
+		event.MsgContent = eventMsgContent
+	} else {
+		newEvent := &ReminderEvent{
+			EventID:    newCalEvent.Id,
+			StartTime:  newStartTime,
+			MsgContent: eventMsgContent,
+		}
+		newEvent.Lock()
+		defer newEvent.Unlock()
+		r.eventMap.Set(newCalEvent.Id, newEvent)
+		for _, minutesBefore := range subscriptionSet.MinutesBefore {
+			if newStartTime.Add(-time.Duration(minutesBefore) * time.Minute).Before(time.Now()) {
+				continue
+			}
+			timestamp := getReminderTimestamp(newStartTime, minutesBefore)
+			newEvent.Subscriptions = append(newEvent.Subscriptions, &ReminderEventSubscriptions{
+				KeybaseConvID: subscriptionSet.KeybaseConvID,
+				Timestamp:     timestamp,
+				MinutesBefore: minutesBefore,
+			})
+			r.Debug("added reminder for %s at %s", newCalEvent.Id, timestamp)
+			r.reminderSchedule.AddReminderToMinute(timestamp, newEvent)
+		}
+	}
+
+	return nil
+}

--- a/gcalbot/gcalbot/reminderscheduler/type.go
+++ b/gcalbot/gcalbot/reminderscheduler/type.go
@@ -1,0 +1,101 @@
+package reminderscheduler
+
+import (
+	"container/list"
+	"sync"
+	"time"
+
+	"github.com/keybase/go-keybase-chat-bot/kbchat/types/chat1"
+)
+
+type ReminderEvent struct {
+	sync.Mutex
+	EventID       string
+	StartTime     time.Time
+	MsgContent    string
+	Subscriptions []*ReminderEventSubscriptions
+}
+
+type ReminderEventSubscriptions struct {
+	KeybaseConvID chat1.ConvIDStr
+	Timestamp     string
+	MinutesBefore int
+}
+
+// Map of eventID (string) -> ReminderEvent (locking)
+type ReminderEventMap struct {
+	syncMap sync.Map
+}
+
+func (r *ReminderEventMap) Get(eventID string) (event *ReminderEvent, ok bool) {
+	val, ok := r.syncMap.Load(eventID)
+	if ok {
+		return val.(*ReminderEvent), ok
+	} else {
+		return nil, ok
+	}
+}
+
+func (r *ReminderEventMap) Set(eventID string, event *ReminderEvent) {
+	r.syncMap.Store(eventID, event)
+}
+
+func (r *ReminderEventMap) Delete(eventID string) {
+	r.syncMap.Delete(eventID)
+}
+
+type ReminderMinute struct {
+	sync.Mutex
+	ReminderList *list.List
+}
+
+// Map of timestamp (string) -> ReminderMinute (locking list)
+type ReminderSchedule struct {
+	syncMap sync.Map
+}
+
+func (r *ReminderSchedule) AddReminderToMinute(timestamp string, reminder *ReminderEvent) {
+	minute, ok := r.get(timestamp)
+	if !ok {
+		minute = &ReminderMinute{}
+		minute.ReminderList = list.New()
+		r.set(timestamp, minute)
+	}
+	minute.Lock()
+	defer minute.Unlock()
+	minute.ReminderList.PushBack(reminder)
+}
+
+func (r *ReminderSchedule) ForEachReminderInMinute(
+	timestamp string,
+	handleEvent func(event *ReminderEvent, remove func()),
+) {
+	minute, ok := r.get(timestamp)
+	if !ok {
+		return
+	}
+	minute.Lock()
+	defer minute.Unlock()
+	for elem := minute.ReminderList.Front(); elem != nil; elem = elem.Next() {
+		event := elem.Value.(*ReminderEvent)
+		remove := func() { minute.ReminderList.Remove(elem) }
+		handleEvent(event, remove)
+	}
+}
+
+func (r *ReminderSchedule) Delete(timestamp string) {
+	r.syncMap.Delete(timestamp)
+}
+
+func (r *ReminderSchedule) get(timestamp string) (minute *ReminderMinute, ok bool) {
+	val, ok := r.syncMap.Load(timestamp)
+	if ok {
+		return val.(*ReminderMinute), ok
+	} else {
+		return nil, ok
+	}
+}
+
+func (r *ReminderSchedule) set(timestamp string, minute *ReminderMinute) {
+	r.syncMap.Store(timestamp, minute)
+}

--- a/gcalbot/gcalbot/reminderscheduler/type.go
+++ b/gcalbot/gcalbot/reminderscheduler/type.go
@@ -17,9 +17,9 @@ type ReminderEvent struct {
 }
 
 type ReminderEventSubscriptions struct {
-	KeybaseConvID chat1.ConvIDStr
-	Timestamp     string
-	MinutesBefore int
+	KeybaseConvID  chat1.ConvIDStr
+	Timestamp      string
+	DurationBefore time.Duration
 }
 
 // Map of eventID (string) -> ReminderEvent (locking)

--- a/gcalbot/gcalbot/reminderscheduler/util.go
+++ b/gcalbot/gcalbot/reminderscheduler/util.go
@@ -2,10 +2,10 @@ package reminderscheduler
 
 import "time"
 
-func getReminderTimestamp(start time.Time, minutesBefore int) string {
+func getReminderTimestamp(start time.Time, durationBefore time.Duration) string {
 	return start.
 		UTC().
-		Add(-time.Duration(minutesBefore) * time.Minute).
+		Add(-durationBefore).
 		Round(time.Minute).
 		Format(time.RFC3339)
 }

--- a/gcalbot/gcalbot/reminderscheduler/util.go
+++ b/gcalbot/gcalbot/reminderscheduler/util.go
@@ -1,0 +1,11 @@
+package reminderscheduler
+
+import "time"
+
+func getReminderTimestamp(start time.Time, minutesBefore int) string {
+	return start.
+		UTC().
+		Add(-time.Duration(minutesBefore) * time.Minute).
+		Round(time.Minute).
+		Format(time.RFC3339)
+}

--- a/gcalbot/gcalbot/util.go
+++ b/gcalbot/gcalbot/util.go
@@ -2,6 +2,7 @@ package gcalbot
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"google.golang.org/api/calendar/v3"
@@ -9,7 +10,8 @@ import (
 
 func FormatTimeRange(
 	startDateTime, endDateTime *calendar.EventDateTime,
-	timezoneID string, format24HourTime bool,
+	timezone *time.Location,
+	format24HourTime bool,
 ) (timeRange string, err error) {
 	// For normal events:
 	//	If the year, month and day are the same: Wed Jan 1, 2020 6:30pm - 7:30pm (EST)
@@ -35,13 +37,8 @@ func FormatTimeRange(
 		if err != nil {
 			return "", err
 		}
-		// set timezone
-		location, err := time.LoadLocation(timezoneID)
-		if err != nil {
-			return "", err
-		}
-		start = start.In(location)
-		end = end.In(location)
+		start = start.In(timezone)
+		end = end.In(timezone)
 	} else if startDateTime.Date != "" && endDateTime.Date != "" {
 		// this is an all day event
 		isAllDay = true
@@ -107,4 +104,20 @@ func FormatTimeRange(
 				start.Format("MST")), nil
 		}
 	}
+}
+
+func GetUserTimezone(srv *calendar.Service) (timezone *time.Location, err error) {
+	timezoneSetting, err := srv.Settings.Get("timezone").Do()
+	if err != nil {
+		return nil, err
+	}
+	return time.LoadLocation(timezoneSetting.Value)
+}
+
+func GetUserFormat24HourTime(srv *calendar.Service) (format24HourTime bool, err error) {
+	format24HourTimeSetting, err := srv.Settings.Get("format24HourTime").Do()
+	if err != nil {
+		return false, err
+	}
+	return strconv.ParseBool(format24HourTimeSetting.Value)
 }

--- a/gcalbot/gcalbot/util.go
+++ b/gcalbot/gcalbot/util.go
@@ -2,8 +2,6 @@ package gcalbot
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"google.golang.org/api/calendar/v3"
@@ -109,63 +107,4 @@ func FormatTimeRange(
 				start.Format("MST")), nil
 		}
 	}
-}
-
-type ReminderDurationUnit string
-
-const (
-	ReminderDurationUnitMinutes ReminderDurationUnit = "minutes"
-	ReminderDurationUnitHours   ReminderDurationUnit = "hours"
-	ReminderDurationUnitDays    ReminderDurationUnit = "days"
-	ReminderDurationUnitWeeks   ReminderDurationUnit = "weeks"
-)
-
-type ReminderDuration struct {
-	Length int
-	Unit   ReminderDurationUnit
-}
-
-func (rd ReminderDuration) String() string {
-	unit := string(rd.Unit)
-	if rd.Length == 1 {
-		unit = strings.TrimSuffix(unit, "s")
-	}
-	return fmt.Sprintf("%d %s", rd.Length, unit)
-}
-
-func ParseReminderDuration(length, unit string) (reminderDuration *ReminderDuration, userErrorMessage string, err error) {
-	// length
-	durationLength, err := strconv.Atoi(length)
-	switch err {
-	case nil:
-	case strconv.ErrSyntax, strconv.ErrRange:
-		return nil, fmt.Sprintf("Error parsing duration before start of event: %s", err.Error()), nil
-	default:
-		return nil, "", err
-	}
-	if durationLength < 0 {
-		return nil, "Duration cannot be negative", nil
-	}
-
-	// unit
-	var durationUnit ReminderDurationUnit
-	switch unit {
-	case "m", "min", "mins", "minute", "minutes":
-		durationUnit = ReminderDurationUnitMinutes
-	case "h", "hr", "hrs", "hour", "hours":
-		durationUnit = ReminderDurationUnitHours
-	case "d", "day", "days":
-		durationUnit = ReminderDurationUnitDays
-	case "w", "wk", "wks", "week", "weeks":
-		durationUnit = ReminderDurationUnitWeeks
-	default:
-		userErrorMessage = fmt.Sprintf(
-			"Unit of time not recognized: %s. Should be one of 'minutes', 'hours', 'days' or 'weeks'.", unit)
-		return nil, userErrorMessage, nil
-	}
-
-	return &ReminderDuration{
-		Length: durationLength,
-		Unit:   durationUnit,
-	}, "", nil
 }

--- a/gcalbot/gcalbot/util.go
+++ b/gcalbot/gcalbot/util.go
@@ -121,3 +121,11 @@ func GetUserFormat24HourTime(srv *calendar.Service) (format24HourTime bool, err 
 	}
 	return strconv.ParseBool(format24HourTimeSetting.Value)
 }
+
+func GetMinutesFromDuration(duration time.Duration) int {
+	return int(duration.Minutes())
+}
+
+func GetDurationFromMinutes(minutes int) time.Duration {
+	return time.Duration(minutes) * time.Minute
+}

--- a/gcalbot/gcalbot/util_test.go
+++ b/gcalbot/gcalbot/util_test.go
@@ -1,9 +1,6 @@
 package gcalbot_test
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
 	"google.golang.org/api/calendar/v3"
@@ -184,28 +181,4 @@ func TestFormatTimeRange(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
 	})
-}
-
-func TestParseReminderDuration(t *testing.T) {
-	unitTable := map[string][]string{
-		"minutes": {"m", "min", "mins", "minute", "minutes"},
-		"hours":   {"h", "hr", "hrs", "hour", "hours"},
-		"days":    {"d", "day", "days"},
-		"weeks":   {"w", "wk", "wks", "week", "weeks"},
-	}
-
-	for unit, suffixList := range unitTable {
-		for length := 0; length <= 4; length++ {
-			expected := fmt.Sprintf("%d %s", length, unit)
-			if length == 1 {
-				expected = strings.TrimSuffix(expected, "s")
-			}
-			for _, suffix := range suffixList {
-				duration, userErr, err := gcalbot.ParseReminderDuration(strconv.Itoa(length), suffix)
-				require.NoError(t, err)
-				require.Empty(t, userErr)
-				require.Equal(t, expected, duration.String())
-			}
-		}
-	}
 }

--- a/gcalbot/gcalbot/util_test.go
+++ b/gcalbot/gcalbot/util_test.go
@@ -2,6 +2,7 @@ package gcalbot_test
 
 import (
 	"testing"
+	"time"
 
 	"google.golang.org/api/calendar/v3"
 
@@ -24,6 +25,8 @@ func TestFormatTimeRange(t *testing.T) {
 
 	t.Run("same year, month and day", func(t *testing.T) {
 		expected := "Wed Jan 1, 2020 6:30pm - 7:30pm (EST)"
+		timezone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
 		actual, err := gcalbot.FormatTimeRange(
 			&calendar.EventDateTime{
 				DateTime: "2020-01-01T18:30:00-05:00",
@@ -31,7 +34,7 @@ func TestFormatTimeRange(t *testing.T) {
 			&calendar.EventDateTime{
 				DateTime: "2020-01-01T19:30:00-05:00",
 			},
-			"America/New_York",
+			timezone,
 			false,
 		)
 		require.NoError(t, err)
@@ -40,6 +43,8 @@ func TestFormatTimeRange(t *testing.T) {
 
 	t.Run("same year and month, different day", func(t *testing.T) {
 		expected := "Wed Jan 1 4:30pm - Thu Jan 2, 2020 6:30pm (EST)"
+		timezone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
 		actual, err := gcalbot.FormatTimeRange(
 			&calendar.EventDateTime{
 				DateTime: "2020-01-01T16:30:00-05:00",
@@ -47,7 +52,7 @@ func TestFormatTimeRange(t *testing.T) {
 			&calendar.EventDateTime{
 				DateTime: "2020-01-02T18:30:00-05:00",
 			},
-			"America/New_York",
+			timezone,
 			false,
 		)
 		require.NoError(t, err)
@@ -56,6 +61,8 @@ func TestFormatTimeRange(t *testing.T) {
 
 	t.Run("same year, different month and day", func(t *testing.T) {
 		expected := "Fri Jan 31 5pm - Sat Feb 1, 2020 6pm (EST)"
+		timezone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
 		actual, err := gcalbot.FormatTimeRange(
 			&calendar.EventDateTime{
 				DateTime: "2020-01-31T17:00:00-05:00",
@@ -63,7 +70,7 @@ func TestFormatTimeRange(t *testing.T) {
 			&calendar.EventDateTime{
 				DateTime: "2020-02-01T18:00:00-05:00",
 			},
-			"America/New_York",
+			timezone,
 			false,
 		)
 		require.NoError(t, err)
@@ -72,6 +79,8 @@ func TestFormatTimeRange(t *testing.T) {
 
 	t.Run("different year, month and day", func(t *testing.T) {
 		expected := "Thu Dec 31, 2020 8:30am - Fri Jan 1, 2021 9:30am (EST)"
+		timezone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
 		actual, err := gcalbot.FormatTimeRange(
 			&calendar.EventDateTime{
 				DateTime: "2020-12-31T08:30:00-05:00",
@@ -79,7 +88,7 @@ func TestFormatTimeRange(t *testing.T) {
 			&calendar.EventDateTime{
 				DateTime: "2021-01-01T09:30:00-05:00",
 			},
-			"America/New_York",
+			timezone,
 			false,
 		)
 		require.NoError(t, err)
@@ -88,6 +97,8 @@ func TestFormatTimeRange(t *testing.T) {
 
 	t.Run("all day same year, month and day", func(t *testing.T) {
 		expected := "Wed Jan 1, 2020"
+		timezone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
 		actual, err := gcalbot.FormatTimeRange(
 			&calendar.EventDateTime{
 				Date: "2020-01-01",
@@ -95,7 +106,7 @@ func TestFormatTimeRange(t *testing.T) {
 			&calendar.EventDateTime{
 				Date: "2020-01-02",
 			},
-			"America/New_York",
+			timezone,
 			false,
 		)
 		require.NoError(t, err)
@@ -104,6 +115,8 @@ func TestFormatTimeRange(t *testing.T) {
 
 	t.Run("all day same year and month, different day", func(t *testing.T) {
 		expected := "Wed Jan 1 - Thu Jan 2, 2020"
+		timezone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
 		actual, err := gcalbot.FormatTimeRange(
 			&calendar.EventDateTime{
 				Date: "2020-01-01",
@@ -111,7 +124,7 @@ func TestFormatTimeRange(t *testing.T) {
 			&calendar.EventDateTime{
 				Date: "2020-01-03",
 			},
-			"America/New_York",
+			timezone,
 			false,
 		)
 		require.NoError(t, err)
@@ -120,6 +133,8 @@ func TestFormatTimeRange(t *testing.T) {
 
 	t.Run("all day same year, different month and day", func(t *testing.T) {
 		expected := "Fri Jan 31 - Sat Feb 1, 2020"
+		timezone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
 		actual, err := gcalbot.FormatTimeRange(
 			&calendar.EventDateTime{
 				Date: "2020-01-31",
@@ -127,7 +142,7 @@ func TestFormatTimeRange(t *testing.T) {
 			&calendar.EventDateTime{
 				Date: "2020-02-02",
 			},
-			"America/New_York",
+			timezone,
 			false,
 		)
 		require.NoError(t, err)
@@ -136,6 +151,8 @@ func TestFormatTimeRange(t *testing.T) {
 
 	t.Run("all day different year, month and day", func(t *testing.T) {
 		expected := "Thu Dec 31, 2020 - Fri Jan 1, 2021"
+		timezone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
 		actual, err := gcalbot.FormatTimeRange(
 			&calendar.EventDateTime{
 				Date: "2020-12-31",
@@ -143,7 +160,7 @@ func TestFormatTimeRange(t *testing.T) {
 			&calendar.EventDateTime{
 				Date: "2021-01-02",
 			},
-			"America/New_York",
+			timezone,
 			false,
 		)
 		require.NoError(t, err)
@@ -152,6 +169,8 @@ func TestFormatTimeRange(t *testing.T) {
 
 	t.Run("24 hour format", func(t *testing.T) {
 		expected := "Fri Jan 31 17:00 - Sat Feb 1, 2020 18:00 (EST)"
+		timezone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
 		actual, err := gcalbot.FormatTimeRange(
 			&calendar.EventDateTime{
 				DateTime: "2020-01-31T17:00:00-05:00",
@@ -159,7 +178,7 @@ func TestFormatTimeRange(t *testing.T) {
 			&calendar.EventDateTime{
 				DateTime: "2020-02-01T18:00:00-05:00",
 			},
-			"America/New_York",
+			timezone,
 			true,
 		)
 		require.NoError(t, err)
@@ -168,6 +187,8 @@ func TestFormatTimeRange(t *testing.T) {
 
 	t.Run("all day 24 hour format", func(t *testing.T) {
 		expected := "Fri Jan 31 - Sat Feb 1, 2020"
+		timezone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
 		actual, err := gcalbot.FormatTimeRange(
 			&calendar.EventDateTime{
 				Date: "2020-01-31",
@@ -175,7 +196,7 @@ func TestFormatTimeRange(t *testing.T) {
 			&calendar.EventDateTime{
 				Date: "2020-02-02",
 			},
-			"America/New_York",
+			timezone,
 			true,
 		)
 		require.NoError(t, err)

--- a/gcalbot/gcalbot/util_test.go
+++ b/gcalbot/gcalbot/util_test.go
@@ -1,6 +1,9 @@
 package gcalbot_test
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"google.golang.org/api/calendar/v3"
@@ -181,4 +184,28 @@ func TestFormatTimeRange(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
 	})
+}
+
+func TestParseReminderDuration(t *testing.T) {
+	unitTable := map[string][]string{
+		"minutes": {"m", "min", "mins", "minute", "minutes"},
+		"hours":   {"h", "hr", "hrs", "hour", "hours"},
+		"days":    {"d", "day", "days"},
+		"weeks":   {"w", "wk", "wks", "week", "weeks"},
+	}
+
+	for unit, suffixList := range unitTable {
+		for length := 0; length <= 4; length++ {
+			expected := fmt.Sprintf("%d %s", length, unit)
+			if length == 1 {
+				expected = strings.TrimSuffix(expected, "s")
+			}
+			for _, suffix := range suffixList {
+				duration, userErr, err := gcalbot.ParseReminderDuration(strconv.Itoa(length), suffix)
+				require.NoError(t, err)
+				require.Empty(t, userErr)
+				require.Equal(t, expected, duration.String())
+			}
+		}
+	}
 }

--- a/gcalbot/main.go
+++ b/gcalbot/main.go
@@ -110,9 +110,9 @@ View your connected Google accounts using %s!gcal accounts list%s
 View existing reminder configurations using %s!gcal reminders list%s
 
 Examples:%s
-!gcal reminders subscribe personal 0
-!gcal reminders subscribe family 5
-!gcal reminders subscribe work 60%s`,
+!gcal reminders unsubscribe personal 0
+!gcal reminders unsubscribe family 5
+!gcal reminders unsubscribe work 60%s`,
 		back, back, back, back, backs, backs)
 
 	remindersListDesc := fmt.Sprintf(`Lists event reminders configured for the primary calendar of a Google account given the account connection's nickname.

--- a/gcalbot/main.go
+++ b/gcalbot/main.go
@@ -92,16 +92,15 @@ Examples:%s
 		back, back, backs, backs)
 
 	remindersSubscribeDesc := fmt.Sprintf(`Subscribes to event reminders over direct message for the primary calendar of a Google account given the account connection's nickname.
+Reminders can be set for 0 minutes up to 60 minutes before the start of an event.
 You can configure multiple event reminders per account.
 View your connected Google accounts using %s!gcal accounts list%s
 View existing reminder configurations using %s!gcal reminders list%s
 
 Examples:%s
-!gcal reminders subscribe personal 5 minutes
-!gcal reminders subscribe personal 30 minutes
-!gcal reminders subscribe family 2 hours
-!gcal reminders subscribe school 3 days
-!gcal reminders subscribe work 1 week%s`,
+!gcal reminders subscribe personal 0
+!gcal reminders subscribe family 5
+!gcal reminders subscribe work 60%s`,
 		back, back, back, back, backs, backs)
 
 	remindersUnsubscribeDesc := fmt.Sprintf(`Unsubscribes from event reminders for the primary calendar of a Google account given the account connection's nickname.
@@ -109,11 +108,9 @@ View your connected Google accounts using %s!gcal accounts list%s
 View existing reminder configurations using %s!gcal reminders list%s
 
 Examples:%s
-!gcal reminders unsubscribe personal 5 minutes
-!gcal reminders unsubscribe personal 30 minutes
-!gcal reminders unsubscribe family 2 hours
-!gcal reminders unsubscribe school 3 days
-!gcal reminders unsubscribe work 1 week%s`,
+!gcal reminders subscribe personal 0
+!gcal reminders subscribe family 5
+!gcal reminders subscribe work 60%s`,
 		back, back, back, back, backs, backs)
 
 	remindersListDesc := fmt.Sprintf(`Lists event reminders configured for the primary calendar of a Google account given the account connection's nickname.
@@ -185,9 +182,9 @@ Examples:%s
 		{
 			Name:        "gcal reminders subscribe",
 			Description: "Subscribe to event reminders over direct message for your primary calendar",
-			Usage:       "<account nickname> <duration before start of event> [minute(s)|hour(s)|day(s)|week(s)]",
+			Usage:       "<account nickname> <minutes before start of event>",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title:       "*!gcal reminders subscribe* <account nickname> <duration before start of event> [minute(s)|hour(s)|day(s)|week(s)]",
+				Title:       "*!gcal reminders subscribe* <account nickname> <minutes before start of event>",
 				DesktopBody: remindersSubscribeDesc,
 				MobileBody:  remindersSubscribeDesc,
 			},
@@ -195,9 +192,9 @@ Examples:%s
 		{
 			Name:        "gcal reminders unsubscribe",
 			Description: "Unsubscribe from event reminders for your primary calendar",
-			Usage:       "<account nickname> <duration before start of event> [minute(s)|hour(s)|day(s)|week(s)]",
+			Usage:       "<account nickname> <minutes before start of event>",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title:       "*!gcal reminders unsubscribe* <account nickname> <duration before start of event> [minute(s)|hour(s)|day(s)|week(s)]",
+				Title:       "*!gcal reminders unsubscribe* <account nickname> <minutes before start of event>",
 				DesktopBody: remindersUnsubscribeDesc,
 				MobileBody:  remindersUnsubscribeDesc,
 			},

--- a/gcalbot/main.go
+++ b/gcalbot/main.go
@@ -75,7 +75,7 @@ Examples:%s
 !gcal calendars list work%s`,
 		back, back, backs, backs)
 
-	invitesSubscribeDesc := fmt.Sprintf(`Subscribes to event invites for the primary calendar of a Google account given the account connection's nickname.
+	invitesSubscribeDesc := fmt.Sprintf(`Subscribes to event invites over direct message for the primary calendar of a Google account given the account connection's nickname.
 View your connected Google accounts using %s!gcal accounts list%s
 
 Examples:%s
@@ -91,7 +91,7 @@ Examples:%s
 !gcal invites unsubscribe work%s`,
 		back, back, backs, backs)
 
-	remindersSubscribeDesc := fmt.Sprintf(`Subscribes to event reminders for the primary calendar of a Google account given the account connection's nickname.
+	remindersSubscribeDesc := fmt.Sprintf(`Subscribes to event reminders over direct message for the primary calendar of a Google account given the account connection's nickname.
 You can configure multiple event reminders per account.
 View your connected Google accounts using %s!gcal accounts list%s
 View existing reminder configurations using %s!gcal reminders list%s
@@ -163,7 +163,7 @@ Examples:%s
 
 		{
 			Name:        "gcal invites subscribe",
-			Description: "Subscribe to event invites for your primary calendar",
+			Description: "Subscribe to event invites over direct message for your primary calendar",
 			Usage:       "<account nickname>",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
 				Title:       "*!gcal invites subscribe* <account nickname>",
@@ -184,7 +184,7 @@ Examples:%s
 
 		{
 			Name:        "gcal reminders subscribe",
-			Description: "Subscribe to event reminders for your primary calendar",
+			Description: "Subscribe to event reminders over direct message for your primary calendar",
 			Usage:       "<account nickname> <duration before start of event> [minute(s)|hour(s)|day(s)|week(s)]",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
 				Title:       "*!gcal reminders subscribe* <account nickname> <duration before start of event> [minute(s)|hour(s)|day(s)|week(s)]",

--- a/gcalbot/main.go
+++ b/gcalbot/main.go
@@ -67,28 +67,61 @@ Examples:%s
 !gcal accounts disconnect work%s`,
 		back, back, backs, backs)
 
-	listCalendarsDesc := fmt.Sprintf(`Lists calendars associated with a Google account given the account connection's nickname.
+	calendarsListDesc := fmt.Sprintf(`Lists calendars associated with a Google account given the account connection's nickname.
 View your connected Google accounts using %s!gcal accounts list%s
 
 Examples:%s
-!gcal list-calendars personal
-!gcal list-calendars work%s`,
+!gcal calendars list personal
+!gcal calendars list work%s`,
 		back, back, backs, backs)
 
-	subscribeInvitesDesc := fmt.Sprintf(`Subscribes to invites for the primary calendar of a Google account given the account connection's nickname.
+	invitesSubscribeDesc := fmt.Sprintf(`Subscribes to event invites for the primary calendar of a Google account given the account connection's nickname.
 View your connected Google accounts using %s!gcal accounts list%s
 
 Examples:%s
-!gcal subscribe invites personal
-!gcal subscribe invites work%s`,
+!gcal invites subscribe personal
+!gcal invites subscribe work%s`,
 		back, back, backs, backs)
 
-	unsubscribeInvitesDesc := fmt.Sprintf(`Unsubscribes from invites for the primary calendar of a Google account given the account connection's nickname.
+	invitesUnsubscribeDesc := fmt.Sprintf(`Unsubscribes from event invites for the primary calendar of a Google account given the account connection's nickname.
 View your connected Google accounts using %s!gcal accounts list%s
 
 Examples:%s
-!gcal unsubscribe invites personal
-!gcal unsubscribe invites work%s`,
+!gcal invites unsubscribe personal
+!gcal invites unsubscribe work%s`,
+		back, back, backs, backs)
+
+	remindersSubscribeDesc := fmt.Sprintf(`Subscribes to event reminders for the primary calendar of a Google account given the account connection's nickname.
+You can configure multiple event reminders per account.
+View your connected Google accounts using %s!gcal accounts list%s
+View existing reminder configurations using %s!gcal reminders list%s
+
+Examples:%s
+!gcal reminders subscribe personal 5 minutes
+!gcal reminders subscribe personal 30 minutes
+!gcal reminders subscribe family 2 hours
+!gcal reminders subscribe school 3 days
+!gcal reminders subscribe work 1 week%s`,
+		back, back, back, back, backs, backs)
+
+	remindersUnsubscribeDesc := fmt.Sprintf(`Unsubscribes from event reminders for the primary calendar of a Google account given the account connection's nickname.
+View your connected Google accounts using %s!gcal accounts list%s
+View existing reminder configurations using %s!gcal reminders list%s
+
+Examples:%s
+!gcal reminders unsubscribe personal 5 minutes
+!gcal reminders unsubscribe personal 30 minutes
+!gcal reminders unsubscribe family 2 hours
+!gcal reminders unsubscribe school 3 days
+!gcal reminders unsubscribe work 1 week%s`,
+		back, back, back, back, backs, backs)
+
+	remindersListDesc := fmt.Sprintf(`Lists event reminders configured for the primary calendar of a Google account given the account connection's nickname.
+View your connected Google accounts using %s!gcal accounts list%s
+
+Examples:%s
+!gcal reminders list personal
+!gcal reminders list work%s`,
 		back, back, backs, backs)
 
 	commands := []chat1.UserBotCommandInput{
@@ -118,34 +151,65 @@ Examples:%s
 		},
 
 		{
-			Name:        "gcal list-calendars",
+			Name:        "gcal calendars list",
 			Description: "List calendars that a Google account is subscribed to",
 			Usage:       "<account nickname>",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title:       "*!gcal list-calendars* <account nickname>",
-				DesktopBody: listCalendarsDesc,
-				MobileBody:  listCalendarsDesc,
+				Title:       "*!gcal calendars list* <account nickname>",
+				DesktopBody: calendarsListDesc,
+				MobileBody:  calendarsListDesc,
 			},
 		},
 
 		{
-			Name:        "gcal subscribe invites",
-			Description: "Subscribe to event invites for your primary calendar.",
+			Name:        "gcal invites subscribe",
+			Description: "Subscribe to event invites for your primary calendar",
 			Usage:       "<account nickname>",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title:       "*!gcal subscribe invites* <account nickname>",
-				DesktopBody: subscribeInvitesDesc,
-				MobileBody:  subscribeInvitesDesc,
+				Title:       "*!gcal invites subscribe* <account nickname>",
+				DesktopBody: invitesSubscribeDesc,
+				MobileBody:  invitesSubscribeDesc,
 			},
 		},
 		{
-			Name:        "gcal unsubscribe invites",
-			Description: "Unsubscribe from event invites for your primary calendar.",
+			Name:        "gcal invites unsubscribe",
+			Description: "Unsubscribe from event invites for your primary calendar",
 			Usage:       "<account nickname>",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title:       "*!gcal unsubscribe invites* <account nickname>",
-				DesktopBody: unsubscribeInvitesDesc,
-				MobileBody:  unsubscribeInvitesDesc,
+				Title:       "*!gcal invites unsubscribe* <account nickname>",
+				DesktopBody: invitesUnsubscribeDesc,
+				MobileBody:  invitesUnsubscribeDesc,
+			},
+		},
+
+		{
+			Name:        "gcal reminders subscribe",
+			Description: "Subscribe to event reminders for your primary calendar",
+			Usage:       "<account nickname> <duration before start of event> [minute(s)|hour(s)|day(s)|week(s)]",
+			ExtendedDescription: &chat1.UserBotExtendedDescription{
+				Title:       "*!gcal reminders subscribe* <account nickname> <duration before start of event> [minute(s)|hour(s)|day(s)|week(s)]",
+				DesktopBody: remindersSubscribeDesc,
+				MobileBody:  remindersSubscribeDesc,
+			},
+		},
+		{
+			Name:        "gcal reminders unsubscribe",
+			Description: "Unsubscribe from event reminders for your primary calendar",
+			Usage:       "<account nickname> <duration before start of event> [minute(s)|hour(s)|day(s)|week(s)]",
+			ExtendedDescription: &chat1.UserBotExtendedDescription{
+				Title:       "*!gcal reminders unsubscribe* <account nickname> <duration before start of event> [minute(s)|hour(s)|day(s)|week(s)]",
+				DesktopBody: remindersUnsubscribeDesc,
+				MobileBody:  remindersUnsubscribeDesc,
+			},
+		},
+		{
+			Name:        "gcal reminders list",
+			Description: "List event reminder configurations for your primary calendar",
+			Usage:       "<account nickname>",
+			ExtendedDescription: &chat1.UserBotExtendedDescription{
+				Title:       "*!gcal reminders list* <account nickname>",
+				DesktopBody: remindersListDesc,
+				MobileBody:  remindersListDesc,
 			},
 		},
 	}


### PR DESCRIPTION
Allows you to set reminders for 0-60 minutes before events for an account's primary calendar sent to you over direct message. This PR does not add support for other calendars or channels.
```
!gcal reminders subscribe personal 0
!gcal reminders subscribe family 5
!gcal reminders subscribe work 60

!gcal reminders unsubscribe personal 0
!gcal reminders unsubscribe family 5
!gcal reminders unsubscribe work 60

!gcal reminders list personal
!gcal reminders list work
```