### PR TITLE
feat: make user prefs per convo

### DIFF
--- a/githubbot/db.sql
+++ b/githubbot/db.sql
@@ -33,6 +33,7 @@ CREATE TABLE `features` (
 
 CREATE TABLE `user_prefs` (
   `username` varchar(128) NOT NULL,
+  `conv_id` char(64) NOT NULL,
   `mention` tinyint(1) NOT NULL,
-  PRIMARY KEY (`username`)
+  UNIQUE KEY unique_prefs (`username`, `conv_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/githubbot/db.sql
+++ b/githubbot/db.sql
@@ -35,5 +35,5 @@ CREATE TABLE `user_prefs` (
   `username` varchar(128) NOT NULL,
   `conv_id` char(64) NOT NULL,
   `mention` tinyint(1) NOT NULL,
-  UNIQUE KEY unique_prefs (`username`, `conv_id`)
+  PRIMARY KEY unique_prefs (`username`, `conv_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/githubbot/githubbot/db.go
+++ b/githubbot/githubbot/db.go
@@ -248,10 +248,10 @@ type UserPreferences struct {
 	Mention bool
 }
 
-func (d *DB) GetUserPreferences(username string) (*UserPreferences, error) {
+func (d *DB) GetUserPreferences(username string, convID chat1.ConvIDStr) (*UserPreferences, error) {
 	row := d.DB.QueryRow(`SELECT mention
 		FROM user_prefs
-		WHERE username = ?`, username)
+		WHERE (username = ? AND conv_id = ?)`, username, convID)
 	prefs := &UserPreferences{}
 	err := row.Scan(&prefs.Mention)
 	switch err {
@@ -267,14 +267,14 @@ func (d *DB) GetUserPreferences(username string) (*UserPreferences, error) {
 	}
 }
 
-func (d *DB) SetUserPreferences(username string, prefs *UserPreferences) error {
+func (d *DB) SetUserPreferences(username string, convID chat1.ConvIDStr, prefs *UserPreferences) error {
 	err := d.RunTxn(func(tx *sql.Tx) error {
 		_, err := tx.Exec(`INSERT INTO user_prefs 
-		(username, mention)
-		VALUES (?, ?)
+		(username, conv_id, mention)
+		VALUES (?, ?, ?)
 		ON DUPLICATE KEY UPDATE
 		mention=VALUES(mention)
-	`, username, prefs.Mention)
+	`, username, convID, prefs.Mention)
 		return err
 	})
 	return err

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -371,15 +371,15 @@ func (h *Handler) handleMentionPref(cmd string, msg chat1.MsgSummary) (err error
 	}
 
 	allowMentions := args[0] == "enable"
-	err = h.db.SetUserPreferences(msg.Sender.Username, &UserPreferences{Mention: allowMentions})
+	err = h.db.SetUserPreferences(msg.Sender.Username, msg.ConvID, &UserPreferences{Mention: allowMentions})
 	if err != nil {
 		return fmt.Errorf("error setting user preference: %s", err)
 	}
 
 	if allowMentions {
-		message = "Okay, you'll be mentioned in GitHub events involving your linked GitHub account."
+		message = "Okay, you'll be mentioned for GitHub events involving your linked GitHub account in this conversation."
 	} else {
-		message = "Okay, you won't be mentioned in future GitHub events."
+		message = "Okay, you won't be mentioned in future GitHub events in this conversation."
 	}
 
 	return

--- a/githubbot/githubbot/util.go
+++ b/githubbot/githubbot/util.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/keybase/go-keybase-chat-bot/kbchat/types/chat1"
+
 	"github.com/keybase/go-keybase-chat-bot/kbchat"
 	"github.com/keybase/managed-bots/base"
 
@@ -171,7 +173,7 @@ type keybaseID struct {
 	Username string `json:"username"`
 }
 
-func getPossibleKBUser(kbc *kbchat.API, d *DB, debug *base.DebugOutput, githubUsername string) (u username) {
+func getPossibleKBUser(kbc *kbchat.API, d *DB, debug *base.DebugOutput, githubUsername string, convID chat1.ConvIDStr) (u username) {
 	u = username{githubUsername: githubUsername}
 	id := kbc.Command("id", "-j", fmt.Sprintf("%s@github", githubUsername))
 	output, err := id.Output()
@@ -187,7 +189,7 @@ func getPossibleKBUser(kbc *kbchat.API, d *DB, debug *base.DebugOutput, githubUs
 		return u
 	}
 
-	prefs, err := d.GetUserPreferences(i.Username)
+	prefs, err := d.GetUserPreferences(i.Username, convID)
 	if err != nil {
 		debug.Debug("getPossibleKBUser: couldn't get user preferences: %s", err)
 		return u

--- a/githubbot/main.go
+++ b/githubbot/main.go
@@ -109,10 +109,6 @@ Examples:%s
 				MobileBody:  mentionsExtended,
 			},
 		},
-		{
-			Name:        "github auth",
-			Description: "Check if GitHub is authenticated for your account.",
-		},
 	}
 	return kbchat.Advertisement{
 		Alias: "GitHub",


### PR DESCRIPTION
changes the mentions preferences so you can have separate mention preferences per convo (basically just adding `conv_id` as a column in the database and getting stuff based on that)