### PR TITLE
Github bot copy tweaks

### DIFF
--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -46,7 +46,7 @@ func NewHandler(kbc *kbchat.API, debugConfig *base.ChatDebugOutputConfig, db *DB
 
 func (h *Handler) HandleNewConv(conv chat1.ConvSummary) error {
 	welcomeMsg := fmt.Sprintf(
-		"Hi! I can notify you whenever something happens on a GitHub repository. To get started, install the Keybase integration on your repository, then send `!github subscribe <username/repo>`\n\ngithub.com/apps/%s/installations/new",
+		"Hi! I can notify you whenever something happens on a GitHub repository. To get started, install the Keybase integration on your repository, then send `!github subscribe <owner/repo>`\n\ngithub.com/apps/%s/installations/new",
 		h.appName,
 	)
 	return base.HandleNewTeam(h.DebugOutput, h.kbc, conv, welcomeMsg)
@@ -105,9 +105,9 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 	args := toks[2:]
 	if len(args) < 1 {
 		if create {
-			h.ChatEcho(msg.ConvID, "I don't understand! Try `!github subscribe <username/repo>`")
+			h.ChatEcho(msg.ConvID, "I don't understand! Try `!github subscribe <owner/repo>`")
 		} else {
-			h.ChatEcho(msg.ConvID, "I don't understand! Try `!github unsubscribe <username/repo>`")
+			h.ChatEcho(msg.ConvID, "I don't understand! Try `!github unsubscribe <owner/repo>`")
 		}
 		return nil
 	}
@@ -177,14 +177,14 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 func (h *Handler) handleNewSubscription(repo string, msg chat1.MsgSummary, client *github.Client) (err error) {
 	parsedRepo := strings.Split(repo, "/")
 	if len(parsedRepo) != 2 {
-		h.ChatEcho(msg.ConvID, "`%s` doesn't look like a repository to me! Try sending `!github subscribe <username/repo>`", repo)
+		h.ChatEcho(msg.ConvID, "`%s` doesn't look like a repository to me! Try sending `!github subscribe <owner/repo>`", repo)
 		return nil
 	}
 	repoInstallation, res, err := client.Apps.FindRepositoryInstallation(context.TODO(), parsedRepo[0], parsedRepo[1])
 	if err != nil {
 		switch res.StatusCode {
 		case http.StatusNotFound:
-			h.ChatEcho(msg.ConvID, "I couldn't subscribe to updates on `%s`! Make sure the app is installed on your repository, and that the repository exists.", repo)
+			h.ChatEcho(msg.ConvID, "I couldn't subscribe to updates on `%s`! Make sure the Keybase integration is installed on your repository, and that the repository exists.\n\ngithub.com/apps/%s/installations/new", repo, h.appName)
 			return nil
 		default:
 			return fmt.Errorf("error getting installation: %s", err)

--- a/githubbot/main.go
+++ b/githubbot/main.go
@@ -57,6 +57,9 @@ const backs = "```"
 
 func (s *BotServer) makeAdvertisement() kbchat.Advertisement {
 	subExtended := fmt.Sprintf(`Enables posting updates from the provided GitHub repository to this conversation.
+	
+Running this command without a branch or event type will subscribe you to all events on the specified repository's default branch.
+
 Event type must be one of %sissues, pulls, commits, statuses%s
 
 Examples:%s
@@ -65,7 +68,10 @@ Examples:%s
 !github subscribe facebook/react gh-pages%s`,
 		backs, backs, backs, backs)
 
-	unsubExtended := fmt.Sprintf(`Disables updates from the provided GitHub repository to this conversation.
+	unsubExtended := fmt.Sprintf(`Disables updates from the provided GitHub repository to this conversation. 
+	
+Running this command without a branch or event type will unsubscribe you from all events on the specified repository.
+
 Event type must be one of %sissues, pulls, commits, statuses%s
 
 Examples:%s
@@ -102,7 +108,7 @@ Examples:%s
 		},
 		{
 			Name:        "github mentions",
-			Description: "Enable or disable mentions in GitHub events for your username.",
+			Description: "Enable or disable mentions in GitHub events for your username in the current conversation.",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
 				Title:       `*!github mentions* <disable/enable>`,
 				DesktopBody: mentionsExtended,

--- a/githubbot/main.go
+++ b/githubbot/main.go
@@ -86,7 +86,7 @@ Examples:%s
 			Name:        "github subscribe",
 			Description: "Enable updates from GitHub repos",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title:       `*!github subscribe* <username/repo> [branch or event type]`,
+				Title:       `*!github subscribe* <owner/repo> [branch or event type]`,
 				DesktopBody: subExtended,
 				MobileBody:  subExtended,
 			},
@@ -95,7 +95,7 @@ Examples:%s
 			Name:        "github unsubscribe",
 			Description: "Disable updates from GitHub repos",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title:       `*!github unsubscribe* <username/repo> [branch or event type]`,
+				Title:       `*!github unsubscribe* <owner/repo> [branch or event type]`,
 				DesktopBody: unsubExtended,
 				MobileBody:  unsubExtended,
 			},

--- a/gitlabbot/gitlabbot/handler.go
+++ b/gitlabbot/gitlabbot/handler.go
@@ -32,7 +32,7 @@ func NewHandler(kbc *kbchat.API, debugConfig *base.ChatDebugOutputConfig,
 }
 
 func (h *Handler) HandleNewConv(conv chat1.ConvSummary) error {
-	welcomeMsg := "Hi! I can notify you whenever something happens on a GitLab repository. To get started, set up a repository by sending `!gitlab subscribe <username/repo>`"
+	welcomeMsg := "Hi! I can notify you whenever something happens on a GitLab repository. To get started, set up a repository by sending `!gitlab subscribe <owner/repo>`"
 	return base.HandleNewTeam(h.DebugOutput, h.kbc, conv, welcomeMsg)
 }
 


### PR DESCRIPTION
Adds app installation link in more places, changes `username/repo` to `owner/repo`, and makes help text a little more clear about what happens if you leave off the branch/event type arg.