### PR TITLE
fix: delete branches from correct table

### DIFF
--- a/githubbot/githubbot/db.go
+++ b/githubbot/githubbot/db.go
@@ -60,7 +60,7 @@ func (d *DB) WatchBranch(convID chat1.ConvIDStr, repo string, branch string) err
 func (d *DB) UnwatchBranch(convID chat1.ConvIDStr, repo string, branch string) error {
 	return d.RunTxn(func(tx *sql.Tx) error {
 		_, err := tx.Exec(`
-			DELETE FROM subscriptions
+			DELETE FROM branches
 			WHERE conv_id = ? AND repo = ? AND branch = ?
 		`, convID, repo, branch)
 		return err


### PR DESCRIPTION
Some code that was missed during a refactor, the unwatch branch function was trying to delete from `subscriptions` instead of `branches`