### PR TITLE
fix: demote gitlab secret validation errors to debug

### DIFF
--- a/gitlabbot/gitlabbot/http.go
+++ b/gitlabbot/gitlabbot/http.go
@@ -125,7 +125,7 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		for _, convID := range convs {
 			var secretToken = base.MakeSecret(repo, convID, h.secret)
 			if signature != secretToken {
-				h.Errorf("Error validating payload signature for conversation %s: %s", convID, err)
+				h.Debug("Error validating payload signature for conversation %s: %s", convID, err)
 				continue
 			}
 			h.ChatEcho(convID, message)


### PR DESCRIPTION
Since this check can fail whenever you have multiple webhooks on the same repo, this isn't really an issue we need to send a full error for.