### PR TITLE
add webhook stats to ghbot

### DIFF
--- a/gcalbot/gcalbot/handler.go
+++ b/gcalbot/gcalbot/handler.go
@@ -31,7 +31,7 @@ func NewHandler(
 ) *Handler {
 	return &Handler{
 		DebugOutput: base.NewDebugOutput("Handler", debugConfig),
-		stats:       stats,
+		stats:       stats.SetPrefix("Handler"),
 		kbc:         kbc,
 		db:          db,
 		config:      config,
@@ -69,31 +69,31 @@ func (h *Handler) HandleCommand(msg chat1.MsgSummary) error {
 
 	switch {
 	case strings.HasPrefix(cmd, "!gcal accounts list"):
-		h.stats.Count("handle - accounts list")
+		h.stats.Count("accounts list")
 		return h.handleAccountsList(msg)
 	case strings.HasPrefix(cmd, "!gcal accounts connect"):
-		h.stats.Count("handle - accounts connect")
+		h.stats.Count("accounts connect")
 		return h.handleAccountsConnect(msg, tokens[3:])
 	case strings.HasPrefix(cmd, "!gcal accounts disconnect"):
-		h.stats.Count("handle - accounts disconnect")
+		h.stats.Count("accounts disconnect")
 		return h.handleAccountsDisconnect(msg, tokens[3:])
 	case strings.HasPrefix(cmd, "!gcal calendars list"):
-		h.stats.Count("handle - calendars list")
+		h.stats.Count("calendars list")
 		return h.handleCalendarsList(msg, tokens[3:])
 	case strings.HasPrefix(cmd, "!gcal invites subscribe"):
-		h.stats.Count("handle - invites subscribe")
+		h.stats.Count("invites subscribe")
 		return h.handleInvitesSubscribe(msg, tokens[3:])
 	case strings.HasPrefix(cmd, "!gcal invites unsubscribe"):
-		h.stats.Count("handle - invites unsubscribe")
+		h.stats.Count("invites unsubscribe")
 		return h.handleInvitesUnsubscribe(msg, tokens[3:])
 	case strings.HasPrefix(cmd, "!gcal reminders subscribe"):
-		h.stats.Count("handle - reminders subscribe")
+		h.stats.Count("reminders subscribe")
 		return h.handleRemindersSubscribe(msg, tokens[3:])
 	case strings.HasPrefix(cmd, "!gcal reminders unsubscribe"):
-		h.stats.Count("handle - reminders unsubscribe")
+		h.stats.Count("reminders unsubscribe")
 		return h.handleRemindersUnsubscribe(msg, tokens[3:])
 	case strings.HasPrefix(cmd, "!gcal reminders list"):
-		h.stats.Count("handle - reminders list")
+		h.stats.Count("reminders list")
 		return h.handleRemindersList(msg, tokens[3:])
 	default:
 		h.ChatEcho(msg.ConvID, "Unknown command %q", cmd)

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -35,7 +35,7 @@ func NewHandler(stats *base.StatsRegistry, kbc *kbchat.API, debugConfig *base.Ch
 	httpPrefix, appName string) *Handler {
 	return &Handler{
 		DebugOutput: base.NewDebugOutput("Handler", debugConfig),
-		stats:       stats,
+		stats:       stats.SetPrefix("Handler"),
 		kbc:         kbc,
 		db:          db,
 		oauthConfig: oauthConfig,
@@ -70,17 +70,17 @@ func (h *Handler) HandleCommand(msg chat1.MsgSummary) error {
 
 	if strings.HasPrefix(cmd, "!github mentions") {
 		// handle user preferences without needing oauth
-		h.stats.Count("handle - mentions")
+		h.stats.Count("mentions")
 		return h.handleMentionPref(cmd, msg)
 	}
 
 	client := github.NewClient(&http.Client{Transport: h.atr})
 	switch {
 	case strings.HasPrefix(cmd, "!github subscribe"):
-		h.stats.Count("handle - subscribe")
+		h.stats.Count("subscribe")
 		return h.handleSubscribe(cmd, msg, true, client)
 	case strings.HasPrefix(cmd, "!github unsubscribe"):
-		h.stats.Count("handle - unsubscribe")
+		h.stats.Count("unsubscribe")
 		return h.handleSubscribe(cmd, msg, false, client)
 	default:
 		h.Debug("ignoring unknown command %q", cmd)

--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -37,7 +37,7 @@ func NewHTTPSrv(stats *base.StatsRegistry, kbc *kbchat.API, debugConfig *base.Ch
 		atr:     atr,
 		secret:  secret,
 	}
-	h.OAuthHTTPSrv = base.NewOAuthHTTPSrv(stats, kbc, debugConfig, oauthConfig, h.db, h.handler.HandleAuth,
+	h.OAuthHTTPSrv = base.NewOAuthHTTPSrv(stats.SetPrefix("HTTPSrv"), kbc, debugConfig, oauthConfig, h.db, h.handler.HandleAuth,
 		"githubbot", base.Images["logo"], "/githubbot")
 	http.HandleFunc("/githubbot", h.handleHealthCheck)
 	http.HandleFunc("/githubbot/webhook", h.handleWebhook)
@@ -52,6 +52,7 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	payload, err := github.ValidatePayload(r, []byte(h.secret))
 	if err != nil {
 		h.Debug("Error validating payload (%s): %s\n", r.Header.Get("X-GitHub-Delivery"), err)
+		h.Stats.Count("webhook - invalid payload")
 		return
 	}
 
@@ -109,6 +110,7 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 
 		if !shouldParseEvent(event, features) {
 			// If a conversation is not subscribed to the feature an event is part of, bail
+			h.Stats.Count("webhook - disabled feature")
 			continue
 		}
 
@@ -131,6 +133,7 @@ func (h *HTTPSrv) handleWebhook(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		h.Stats.Count("webhook - success")
 		_, err = h.kbc.SendMessageByConvID(convID, message)
 		if err != nil {
 			h.Debug("Error sending message: %s", err)

--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -37,7 +37,7 @@ func NewHTTPSrv(stats *base.StatsRegistry, kbc *kbchat.API, debugConfig *base.Ch
 		atr:     atr,
 		secret:  secret,
 	}
-	h.OAuthHTTPSrv = base.NewOAuthHTTPSrv(stats.SetPrefix("HTTPSrv"), kbc, debugConfig, oauthConfig, h.db, h.handler.HandleAuth,
+	h.OAuthHTTPSrv = base.NewOAuthHTTPSrv(stats, kbc, debugConfig, oauthConfig, h.db, h.handler.HandleAuth,
 		"githubbot", base.Images["logo"], "/githubbot")
 	http.HandleFunc("/githubbot", h.handleHealthCheck)
 	http.HandleFunc("/githubbot/webhook", h.handleWebhook)

--- a/gitlabbot/gitlabbot/handler.go
+++ b/gitlabbot/gitlabbot/handler.go
@@ -25,7 +25,7 @@ func NewHandler(stats *base.StatsRegistry, kbc *kbchat.API, debugConfig *base.Ch
 	db *DB, httpPrefix string, secret string) *Handler {
 	return &Handler{
 		DebugOutput: base.NewDebugOutput("Handler", debugConfig),
-		stats:       stats,
+		stats:       stats.SetPrefix("Handler"),
 		kbc:         kbc,
 		db:          db,
 		httpPrefix:  httpPrefix,
@@ -54,10 +54,10 @@ func (h *Handler) HandleCommand(msg chat1.MsgSummary) error {
 
 	switch {
 	case strings.HasPrefix(cmd, "!gitlab subscribe"):
-		h.stats.Count("handle - subscribe")
+		h.stats.Count("subscribe")
 		return h.handleSubscribe(cmd, msg, true)
 	case strings.HasPrefix(cmd, "!gitlab unsubscribe"):
-		h.stats.Count("handle - unsubscribe")
+		h.stats.Count("unsubscribe")
 		return h.handleSubscribe(cmd, msg, false)
 	}
 	return nil

--- a/meetbot/meetbot/handler.go
+++ b/meetbot/meetbot/handler.go
@@ -29,7 +29,7 @@ func NewHandler(stats *base.StatsRegistry, kbc *kbchat.API, debugConfig *base.Ch
 	db *base.GoogleOAuthDB, config *oauth2.Config) *Handler {
 	return &Handler{
 		DebugOutput: base.NewDebugOutput("Handler", debugConfig),
-		stats:       stats,
+		stats:       stats.SetPrefix("Handler"),
 		kbc:         kbc,
 		db:          db,
 		config:      config,
@@ -53,7 +53,7 @@ func (h *Handler) HandleCommand(msg chat1.MsgSummary) error {
 	cmd := strings.TrimSpace(msg.Content.Text.Body)
 	switch {
 	case strings.HasPrefix(cmd, "!meet"):
-		h.stats.Count("handle - meet")
+		h.stats.Count("meet")
 		return h.meetHandler(msg)
 	}
 	return nil

--- a/triviabot/triviabot/handler.go
+++ b/triviabot/triviabot/handler.go
@@ -27,7 +27,7 @@ var _ base.Handler = (*Handler)(nil)
 func NewHandler(stats *base.StatsRegistry, kbc *kbchat.API, debugConfig *base.ChatDebugOutputConfig, db *DB) *Handler {
 	return &Handler{
 		DebugOutput: base.NewDebugOutput("Handler", debugConfig),
-		stats:       stats,
+		stats:       stats.SetPrefix("Handler"),
 		kbc:         kbc,
 		debugConfig: debugConfig,
 		db:          db,
@@ -125,16 +125,16 @@ func (h *Handler) HandleCommand(msg chat1.MsgSummary) error {
 	cmd := strings.TrimSpace(msg.Content.Text.Body)
 	switch {
 	case strings.HasPrefix(cmd, "!trivia begin"):
-		h.stats.Count("handle - start")
+		h.stats.Count("start")
 		h.handleStart(cmd, msg)
 	case strings.HasPrefix(cmd, "!trivia end"):
-		h.stats.Count("handle - stop")
+		h.stats.Count("stop")
 		h.handleStop(cmd, msg)
 	case strings.HasPrefix(cmd, "!trivia top"):
-		h.stats.Count("handle - top")
+		h.stats.Count("top")
 		return h.handleTop(msg.ConvID)
 	case strings.HasPrefix(cmd, "!trivia reset"):
-		h.stats.Count("handle - reset")
+		h.stats.Count("reset")
 		return h.handleReset(cmd, msg)
 	}
 	return nil

--- a/webhookbot/webhookbot/http.go
+++ b/webhookbot/webhookbot/http.go
@@ -15,8 +15,7 @@ import (
 type HTTPSrv struct {
 	*base.HTTPSrv
 
-	db    *DB
-	stats *base.StatsRegistry
+	db *DB
 }
 
 func NewHTTPSrv(stats *base.StatsRegistry, debugConfig *base.ChatDebugOutputConfig, db *DB) *HTTPSrv {


### PR DESCRIPTION
uses SetPrefix on handler stats, adds webhook stats (success, invalid payload, disabled feature hooks)