### PR TITLE
fix ci

### DIFF
--- a/pollbot/pollbot/vote.go
+++ b/pollbot/pollbot/vote.go
@@ -25,16 +25,10 @@ func NewVoteFromEncoded(sdat string) Vote {
 	var ve voteToEncode
 	dat, _ := base.URLEncoder().DecodeString(sdat)
 	_ = base.MsgpackDecode(&ve, dat)
-	return Vote{
-		ID:     ve.ID,
-		Choice: ve.Choice,
-	}
+	return Vote(ve)
 }
 
 func (v Vote) Encode() string {
-	mdat, _ := base.MsgpackEncode(voteToEncode{
-		ID:     v.ID,
-		Choice: v.Choice,
-	})
+	mdat, _ := base.MsgpackEncode(voteToEncode(v))
 	return base.URLEncoder().EncodeToString(mdat)
 }


### PR DESCRIPTION
fixes: 
```
$ golangci-lint run
pollbot/pollbot/vote.go:28:9: S1016: should convert ve (type voteToEncode) to Vote instead of using struct literal (gosimple)
return Vote{

	       ^

pollbot/pollbot/vote.go:35:32: S1016: should convert v (type Vote) to voteToEncode instead of using struct literal (gosimple)

	mdat, _ := base.MsgpackEncode(voteToEncode{
	                                                       ^

The command "golangci-lint run" exited with 1.
```