### PR TITLE
fix: filter pull requests without repo as base in status events

### DIFF
--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -213,7 +213,7 @@ func (h *HTTPSrv) formatMessage(convID chat1.ConvIDStr, event interface{}, repo 
 				break
 			}
 		}
-		if runPR != nil {
+		if runPR == nil {
 			// this is a branch test, not associated with a PR
 			branch = event.GetCheckRun().GetCheckSuite().GetHeadBranch()
 			// don't provide an author since it's not a PR
@@ -251,6 +251,7 @@ func (h *HTTPSrv) formatMessage(convID chat1.ConvIDStr, event interface{}, repo 
 		for _, pr := range pullRequests {
 			if pr.GetBase().GetRepo().GetFullName() == repo {
 				runPR = pr
+				break
 			}
 		}
 

--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -202,7 +202,16 @@ func (h *HTTPSrv) formatMessage(convID chat1.ConvIDStr, event interface{}, repo 
 
 	case *github.CheckRunEvent:
 		var author username
-		if len(event.GetCheckRun().PullRequests) == 0 {
+		// filter checkrun prs by base (they must be AGAINST THE SUBSCRIBED REPO)
+		var runPRs []*github.PullRequest
+		// the repo object returned by the GetCheckRun call is very sparse, so we really only can check against the api url
+		repoAPIUrl := fmt.Sprintf("https://api.github.com/repos/%s", repo)
+		for _, pr := range event.GetCheckRun().PullRequests {
+			if pr.GetBase().GetRepo().GetURL() == repoAPIUrl {
+				runPRs = append(runPRs, pr)
+			}
+		}
+		if len(runPRs) == 0 {
 			// this is a branch test, not associated with a PR
 			branch = event.GetCheckRun().GetCheckSuite().GetHeadBranch()
 			// don't provide an author since it's not a PR
@@ -210,7 +219,7 @@ func (h *HTTPSrv) formatMessage(convID chat1.ConvIDStr, event interface{}, repo 
 		}
 
 		// fetch the pull request object so we can get the right author
-		pr, _, err := client.PullRequests.Get(context.TODO(), parsedRepo[0], parsedRepo[1], event.GetCheckRun().PullRequests[0].GetNumber())
+		pr, _, err := client.PullRequests.Get(context.TODO(), parsedRepo[0], parsedRepo[1], runPRs[0].GetNumber())
 		if err != nil {
 			h.Errorf("Error getting pull request object: %s", err)
 			return formatCheckRunMessage(event, ""), branch
@@ -235,8 +244,16 @@ func (h *HTTPSrv) formatMessage(convID chat1.ConvIDStr, event interface{}, repo 
 			h.Errorf("error getting pull requests from commit: %s", err)
 		}
 
-		if len(pullRequests) >= 1 {
-			author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, pullRequests[0].GetUser().GetLogin(), convID)
+		// we have to filter PRs that are not against the repo in question
+		var runPRs []*github.PullRequest
+		for _, pr := range pullRequests {
+			if pr.GetBase().GetRepo().GetFullName() == repo {
+				runPRs = append(runPRs, pr)
+			}
+		}
+
+		if len(runPRs) >= 1 {
+			author = getPossibleKBUser(h.kbc, h.db, h.DebugOutput, runPRs[0].GetUser().GetLogin(), convID)
 		} else if len(event.Branches) >= 1 {
 			// this is a branch test, not associated with a PR
 			branch = event.Branches[0].GetName()


### PR DESCRIPTION
The Github API returns some pull requests we don't really want to associate with a particular check run/status event (i.e. ones that have the subscribed repo as the head, not the base), which makes for some really confusing messages and errors. This PR fixes that by filtering out PRs in status and check run events that don't have the provided repo as the base.