### PR TITLE
Use IssuesEvent sender for event author

### DIFF
--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -152,7 +152,7 @@ func (h *HTTPSrv) formatMessage(convID chat1.ConvIDStr, event interface{}, repo 
 	branch = defaultBranch
 	switch event := event.(type) {
 	case *github.IssuesEvent:
-		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetIssue().GetUser().GetLogin(), convID)
+		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin(), convID)
 		return git.FormatIssueMsg(
 			*event.Action,
 			author.String(),


### PR DESCRIPTION
Fixes #139 by using the Sender on an issues event instead of the issue's original author. 