### PR TITLE
Add top-level !github list command

### DIFF
--- a/githubbot/githubbot/db.go
+++ b/githubbot/githubbot/db.go
@@ -145,6 +145,25 @@ func (d *DB) GetSubscriptionForRepoExists(convID chat1.ConvIDStr, repo string) (
 	}
 }
 
+func (d *DB) GetAllBranchesForRepo(convID chat1.ConvIDStr, repo string) ([]string, error) {
+	rows, err := d.DB.Query(`SELECT branch
+		FROM branches
+		WHERE conv_id = ? AND repo = ?`, convID, repo)
+	if err != nil {
+		return nil, err
+	}
+	res := []string{}
+	defer rows.Close()
+	for rows.Next() {
+		var branch string
+		if err := rows.Scan(&branch); err != nil {
+			return res, err
+		}
+		res = append(res, branch)
+	}
+	return res, nil
+}
+
 // subscription preferences
 
 type Features struct {

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -340,7 +340,7 @@ func (h *Handler) handleSubscribeToBranch(repo, branch string, msg chat1.MsgSumm
 			return fmt.Errorf("error creating branch subscription: %s", err)
 		}
 
-		h.ChatEcho(msg.ConvID, "Now subscribed to commits on `%s/%s`.", repo, branch)
+		h.ChatEcho(msg.ConvID, "Now subscribed to notifications for `%s/%s`.", repo, branch)
 		return nil
 	}
 	err = h.db.UnwatchBranch(msg.ConvID, repo, branch)
@@ -348,7 +348,7 @@ func (h *Handler) handleSubscribeToBranch(repo, branch string, msg chat1.MsgSumm
 		return fmt.Errorf("error deleting branch subscription: %s", err)
 	}
 
-	h.ChatEcho(msg.ConvID, "Okay, you won't receive notifications for commits in `%s/%s`.", repo, branch)
+	h.ChatEcho(msg.ConvID, "Okay, you won't receive notifications for `%s/%s`.", repo, branch)
 	return nil
 }
 

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -265,6 +265,16 @@ func (h *Handler) handleNewSubscription(repo string, msg chat1.MsgSummary, clien
 	}
 
 	// auth checked, now we create the subscription
+	defaultBranch, err := getDefaultBranch(repo, userClient)
+	if err != nil {
+		return false, fmt.Errorf("error getting default branch: %s", err)
+	}
+
+	err = h.db.WatchBranch(msg.ConvID, repo, defaultBranch)
+	if err != nil {
+		return false, fmt.Errorf("error watching branch: %s", err)
+	}
+
 	err = h.db.CreateSubscription(msg.ConvID, repo, repoInstallation.GetID())
 	if err != nil {
 		return false, fmt.Errorf("error creating subscription: %s", err)

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -2,7 +2,6 @@ package githubbot
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"net/http"
 	"strings"
@@ -100,20 +99,7 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 		return nil
 	}
 
-	var list bool
-	flags := flag.NewFlagSet(toks[0], flag.ContinueOnError)
-	flags.BoolVar(&list, "list", false, "")
-	if err := flags.Parse(toks[2:]); err != nil {
-		h.ChatEcho(msg.ConvID, "failed to parse subscribe command: %s", err)
-		return nil
-	}
-	if list {
-		// TODO: this should be removed once we're pretty sure nobody is using it
-		h.stats.Count("subscribe - list")
-		return h.handleListSubscriptions(msg)
-	}
-
-	args := flags.Args()
+	args := toks[2:]
 	if len(args) < 1 {
 		if create {
 			h.ChatEcho(msg.ConvID, "I don't understand! Try `!github subscribe <owner/repo>`")

--- a/githubbot/main.go
+++ b/githubbot/main.go
@@ -117,7 +117,7 @@ Examples:%s
 		},
 		{
 			Name:        "github list",
-			Description: "List subscriptions in the current conversation.",
+			Description: "List subscriptions for the current conversation.",
 		},
 		base.GetFeedbackCommandAdvertisement(s.kbc.GetUsername()),
 	}

--- a/githubbot/main.go
+++ b/githubbot/main.go
@@ -65,8 +65,7 @@ Event type must be one of %sissues, pulls, commits, statuses%s
 Examples:%s
 !github subscribe keybase/client
 !github subscribe microsoft/typescript pulls
-!github subscribe facebook/react gh-pages
-!github subscribe --list%s`,
+!github subscribe facebook/react gh-pages%s`,
 		backs, backs, backs, backs)
 
 	unsubExtended := fmt.Sprintf(`Disables updates from the provided GitHub repository to this conversation.
@@ -115,6 +114,10 @@ Examples:%s
 				DesktopBody: mentionsExtended,
 				MobileBody:  mentionsExtended,
 			},
+		},
+		{
+			Name:        "github list",
+			Description: "List subscriptions in the current conversation.",
 		},
 		base.GetFeedbackCommandAdvertisement(s.kbc.GetUsername()),
 	}

--- a/gitlabbot/gitlabbot/handler.go
+++ b/gitlabbot/gitlabbot/handler.go
@@ -205,10 +205,7 @@ func (h *Handler) handleListSubscriptions(msg chat1.MsgSummary) (err error) {
 			res += fmt.Sprintf("- *%s*\n", sub.repo)
 		}
 
-		if sub.branch != "master" {
-			res += fmt.Sprintf("\t- %s\n", sub.branch)
-		}
-
+		res += fmt.Sprintf("   - %s\n", sub.branch)
 		prevRepo = sub.repo
 	}
 	h.ChatEcho(msg.ConvID, res)


### PR DESCRIPTION
Replaces `!github subscribe --list` with `!github list` and adds subscribed branches to the list message