### PR TITLE
delete stopped session

### DIFF
--- a/triviabot/triviabot/handler.go
+++ b/triviabot/triviabot/handler.go
@@ -65,6 +65,7 @@ func (h *Handler) handleStop(cmd string, msg chat1.MsgSummary) {
 		return
 	}
 	session.stop()
+	delete(h.sessions, convID)
 	h.ChatEcho(convID, "Session stopped")
 }
 


### PR DESCRIPTION
fixes:
```
panic: close of closed channel stack trace: goroutine 37 [running]:
runtime/debug.Stack(0xc000311400, 0xbfecc0, 0xf03b10)
    /usr/local/go/src/runtime/debug/stack.go:24 +0x9d
github.com/keybase/managed-bots/base.PanicRecover(0xc00009f8a0)
    /managed-bots/base/errors.go:15 +0x57
panic(0xbfecc0, 0xf03b10)
    /usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/keybase/managed-bots/triviabot/triviabot.(*session).stop(...)
    /managed-bots/triviabot/triviabot/session.go:379
github.com/keybase/managed-bots/triviabot/triviabot.(*Handler).handleStop(0xc000068540, 0xc000528cb4, 0xb, 0x25, 0xc000438300, 0x40, 0xc000528c78, 0x6, 0x0, 0xc000528c80, ...)
    /managed-bots/triviabot/triviabot/handler.go:67 +0xe6
github.com/keybase/managed-bots/triviabot/triviabot.(*Handler).HandleCommand(0xc000068540, 0x25, 0xc000438300, 0x40, 0xc000528c78, 0x6, 0x0, 0xc000528c80, 0x4, 0xc000528c84, ...)
    /managed-bots/triviabot/triviabot/handler.go:132 +0x342
github.com/keybase/managed-bots/base.(*Server).listenForMsgs(0xc0002d8100, 0xc00002a180, 0xc000364000, 0xf20360, 0xc000068540, 0x0, 0x0)
    /managed-bots/base/server.go:200 +0x1b6
github.com/keybase/managed-bots/base.(*Server).Listen.func1(0xc00036a708, 0x0)
    /managed-bots/base/server.go:143 +0x4e
github.com/keybase/managed-bots/base.GoWithRecoverErrGroup.func1(0x0, 0x0)
    /managed-bots/base/errors.go:24 +0x6b
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc000308510, 0xc00009fd00)
    /go/pkg/mod/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:57 +0x64
created by golang.org/x/sync/errgroup.(*Group).Go
    /go/pkg/mod/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e/errgroup/errgroup.go:54 +0x66
```