### PR TITLE
gcalbot: daily schedule default time 7:30am -> 10:00am

### DIFF
--- a/gcalbot/gcalbot/http.go
+++ b/gcalbot/gcalbot/http.go
@@ -286,7 +286,7 @@ func (h *HTTPSrv) configHandler(w http.ResponseWriter, r *http.Request) {
 			// sane defaults
 			page.DSDays = DaysToSendEveryday
 			page.DSSchedule = ScheduleToSendToday
-			page.DSTime = "450" // 7:30am is a sane default
+			page.DSTime = "600" // 10:00am is a sane default
 
 			var timezone *time.Location
 			timezone, err = GetUserTimezone(srv)


### PR DESCRIPTION
Suggested by @joshblum 
<img width="811" alt="Screen Shot 2020-02-27 at 11 45 35 AM" src="https://user-images.githubusercontent.com/6353492/75465458-acd63380-5956-11ea-9f29-4629de39bc75.png">
