### PR TITLE
gcalbot: improve event formatting

### DIFF
--- a/gcalbot/gcalbot/event.go
+++ b/gcalbot/gcalbot/event.go
@@ -24,14 +24,14 @@ func FormatEvent(
 	format24HourTime bool,
 ) (string, error) {
 	message := `%s
-> What: *%s*
 > When: %s%s%s%s
-> Calendar: %s%s`
+> Calendar: %s%s
+%s`
 
-	// strip protocol to skip unfurl prompt
-	url := strings.TrimPrefix(event.HtmlLink, "https://")
-
-	what := event.Summary
+	var what string
+	if event.Summary != "" {
+		what = fmt.Sprintf("\n> What: *%s*", event.Summary)
+	}
 
 	// TODO(marcel): better date formatting for recurring events
 	when, err := FormatTimeRange(event.Start, event.End, timezone, format24HourTime)
@@ -97,8 +97,11 @@ func FormatEvent(
 		}
 	}
 
+	// strip protocol to skip unfurl prompt
+	url := strings.TrimPrefix(event.HtmlLink, "https://")
+
 	return fmt.Sprintf(message,
-		url, what, when, where, conferenceData, organizer, calendarSummary, description), nil
+		what, when, where, conferenceData, organizer, calendarSummary, description, url), nil
 }
 
 func FormatEventSchedule(

--- a/gcalbot/gcalbot/reminderscheduler/send.go
+++ b/gcalbot/gcalbot/reminderscheduler/send.go
@@ -1,6 +1,7 @@
 package reminderscheduler
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/keybase/managed-bots/gcalbot/gcalbot"
@@ -41,11 +42,17 @@ func (r *ReminderScheduler) sendReminders(sendMinute time.Time) {
 			msgTimestamp := getReminderTimestamp(msg.StartTime, duration)
 			if msgTimestamp == timestamp {
 				minutesBefore := gcalbot.GetMinutesFromDuration(duration)
-				if minutesBefore == 0 {
-					r.ChatEcho(msg.KeybaseConvID, "An event is starting now: %s", msg.MsgContent)
+				var eventSummary string
+				if msg.EventSummary != "" {
+					eventSummary = fmt.Sprintf(`"%s"`, msg.EventSummary)
 				} else {
-					r.ChatEcho(msg.KeybaseConvID, "An event is starting in %s: %s",
-						gcalbot.MinutesBeforeString(minutesBefore), msg.MsgContent)
+					eventSummary = "An event"
+				}
+				if minutesBefore == 0 {
+					r.ChatEcho(msg.KeybaseConvID, "%s is starting now: %s", eventSummary, msg.MsgContent)
+				} else {
+					r.ChatEcho(msg.KeybaseConvID, "%s is starting in %s: %s",
+						eventSummary, gcalbot.MinutesBeforeString(minutesBefore), msg.MsgContent)
 				}
 				delete(msg.MinuteReminders, duration)
 				r.stats.Count("sendReminders - reminder")

--- a/gcalbot/gcalbot/reminderscheduler/sync.go
+++ b/gcalbot/gcalbot/reminderscheduler/sync.go
@@ -153,12 +153,14 @@ func (r *ReminderScheduler) UpdateOrCreateReminderEvent(
 			}
 		}
 
+		reminderMessage.EventSummary = event.Summary
 		reminderMessage.MsgContent = eventMsgContent
 	} else {
 		// create the event
 		r.stats.Count("UpdateOrCreateReminderEvent - create")
 		reminderMessage = &ReminderMessage{
 			EventID:         event.Id,
+			EventSummary:    event.Summary,
 			KeybaseUsername: account.KeybaseUsername,
 			AccountNickname: account.AccountNickname,
 			CalendarID:      subscription.CalendarID,

--- a/gcalbot/gcalbot/reminderscheduler/type.go
+++ b/gcalbot/gcalbot/reminderscheduler/type.go
@@ -14,7 +14,8 @@ type ReminderTimestamp string
 type ReminderMessage struct {
 	sync.Mutex
 
-	EventID string
+	EventID      string
+	EventSummary string
 
 	KeybaseUsername string
 	AccountNickname string


### PR DESCRIPTION
Before (event with name and event with no name):
<img width="920" alt="Screen Shot 2020-02-27 at 12 14 04 PM" src="https://user-images.githubusercontent.com/6353492/75468079-a77ae800-595a-11ea-9807-873954603e50.png">
After (event with name and event with no name):
<img width="709" alt="Screen Shot 2020-02-27 at 12 14 30 PM" src="https://user-images.githubusercontent.com/6353492/75468118-b6fa3100-595a-11ea-901a-0389944f42d4.png">
