### PR TITLE
gcalbot: don't lock the save button on push err

### DIFF
--- a/gcalbot/gcalbot/html.go
+++ b/gcalbot/gcalbot/html.go
@@ -357,8 +357,7 @@ const tmplConfig = `{{template "header" .}}
 		<div class="row">
 		<input type="submit" value="Save" class="save-button"
 			onclick="this.form.submit(); this.disabled=true; this.value='Saving...';
-					 if(document.getElementById('save-success')) { document.getElementById('save-success').style.display='none' };"
-			{{if .PushNotAllowed}} disabled {{end}}>
+					 if(document.getElementById('save-success')) { document.getElementById('save-success').style.display='none' };">
 		{{if .Updated}}<span id="save-success" class="save-status">Saved!</span>{{end}}
 		{{if .PushNotAllowed}}<span id="save-error" class="save-status">Push notifications are not supported for this calendar</span>{{end}}
 		</div>


### PR DESCRIPTION
Don't disable the save button if push notifications aren't supported (because the daily schedule can still be set)
<img width="624" alt="Screen Shot 2020-02-28 at 1 29 58 PM" src="https://user-images.githubusercontent.com/6353492/75576698-6d7b1600-5a2e-11ea-8a47-3dab8728fb7e.png">
