### PR TITLE
gcalbot: suppress revoked token errors

### DIFF
--- a/gcalbot/gcalbot/calendar.go
+++ b/gcalbot/gcalbot/calendar.go
@@ -25,7 +25,7 @@ func (h *Handler) handleCalendarsList(msg chat1.MsgSummary, args []string) error
 		return nil
 	}
 
-	srv, err := GetCalendarService(account, h.oauth)
+	srv, err := GetCalendarService(account, h.oauth, h.db)
 	if err != nil {
 		return err
 	}

--- a/gcalbot/gcalbot/http.go
+++ b/gcalbot/gcalbot/http.go
@@ -197,7 +197,7 @@ func (h *HTTPSrv) configHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	srv, err := GetCalendarService(selectedAccount, h.oauth)
+	srv, err := GetCalendarService(selectedAccount, h.oauth, h.db)
 	if err != nil {
 		return
 	}

--- a/gcalbot/gcalbot/invite.go
+++ b/gcalbot/gcalbot/invite.go
@@ -39,7 +39,7 @@ Awaiting your response. *Are you going?*`
 		eventType = "a recurring event"
 	}
 
-	srv, err := GetCalendarService(account, h.oauth)
+	srv, err := GetCalendarService(account, h.oauth, h.db)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (h *Handler) updateEventResponseStatus(invite *Invite, account *Account, re
 		return nil
 	}
 
-	srv, err := GetCalendarService(account, h.oauth)
+	srv, err := GetCalendarService(account, h.oauth, h.db)
 	if err != nil {
 		return err
 	}

--- a/gcalbot/gcalbot/oauth.go
+++ b/gcalbot/gcalbot/oauth.go
@@ -84,7 +84,7 @@ func (h *HTTPSrv) oauthHandler(w http.ResponseWriter, r *http.Request) {
 	// if account was created in a 1on1 conv, create default subscription to invites & 5 minute reminder for primary calendar
 	if base.IsDirectPrivateMessage(h.kbc.GetUsername(), req.KeybaseUsername, conv.Channel) {
 		var srv *calendar.Service
-		srv, err = GetCalendarService(&account, h.oauth)
+		srv, err = GetCalendarService(&account, h.oauth, h.db)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Specifically for webhooks and scheduled tasks (ie. reminders, schedules)