### PR TITLE
jirabot: show cmd, unfurl, better error message

### DIFF
--- a/jirabot/package.json
+++ b/jirabot/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.4",
+    "is-valid-domain": "^0.0.14",
     "jira-connector": "2.16.1",
     "keybase-bot": "3.6.1",
     "mem": "^6.0.1",

--- a/jirabot/package.json
+++ b/jirabot/package.json
@@ -22,6 +22,7 @@
     "jira-connector": "2.16.1",
     "keybase-bot": "3.6.1",
     "mem": "^6.0.1",
+    "moment": "^2.24.0",
     "pino": "^5.14.0"
   },
   "scripts": {

--- a/jirabot/src/bot.ts
+++ b/jirabot/src/bot.ts
@@ -9,6 +9,7 @@ import CmdNew from './cmd-new'
 import CmdConfig from './cmd-config'
 import CmdFeed from './cmd-feed'
 import CmdDebug from './cmd-debug'
+import CmdShow from './cmd-show'
 import {Context} from './context'
 import logger from './logger'
 import * as Utils from './utils'
@@ -68,42 +69,33 @@ const onMessage = async (
         reportError(context, parsedMessage)
         return
       case Message.BotMessageType.Search: {
-        reactAck(context, parsedMessage.context, kbMessage.id)
         const {type} = await CmdSearch(context, parsedMessage)
-        type === Errors.ReturnType.Ok
-          ? reactDone(context, parsedMessage.context, kbMessage.id)
-          : reactFail(context, parsedMessage.context, kbMessage.id)
+        type !== Errors.ReturnType.Ok &&
+          reactFail(context, parsedMessage.context, kbMessage.id)
         return
       }
       case Message.BotMessageType.Comment: {
-        reactAck(context, parsedMessage.context, kbMessage.id)
         const {type} = await CmdComment(context, parsedMessage)
-        type === Errors.ReturnType.Ok
-          ? reactDone(context, parsedMessage.context, kbMessage.id)
-          : reactFail(context, parsedMessage.context, kbMessage.id)
+        type !== Errors.ReturnType.Ok &&
+          reactFail(context, parsedMessage.context, kbMessage.id)
         return
       }
       case Message.BotMessageType.Reacji:
         reacji(context, parsedMessage)
         return
       case Message.BotMessageType.Create: {
-        reactAck(context, parsedMessage.context, kbMessage.id)
         const {type} = await CmdNew(context, parsedMessage)
-        type === Errors.ReturnType.Ok
-          ? reactDone(context, parsedMessage.context, kbMessage.id)
-          : reactFail(context, parsedMessage.context, kbMessage.id)
+        type !== Errors.ReturnType.Ok &&
+          reactFail(context, parsedMessage.context, kbMessage.id)
         return
       }
       case Message.BotMessageType.Config: {
-        reactAck(context, parsedMessage.context, kbMessage.id)
         const {type} = await CmdConfig(context, parsedMessage)
-        type === Errors.ReturnType.Ok
-          ? reactDone(context, parsedMessage.context, kbMessage.id)
-          : reactFail(context, parsedMessage.context, kbMessage.id)
+        type !== Errors.ReturnType.Ok &&
+          reactFail(context, parsedMessage.context, kbMessage.id)
         return
       }
       case Message.BotMessageType.Auth: {
-        reactAck(context, parsedMessage.context, kbMessage.id)
         const {type} = await CmdAuth(context, parsedMessage)
         type === Errors.ReturnType.Ok
           ? reactDone(context, parsedMessage.context, kbMessage.id)
@@ -111,11 +103,9 @@ const onMessage = async (
         return
       }
       case Message.BotMessageType.Feed: {
-        reactAck(context, parsedMessage.context, kbMessage.id)
         const {type} = await CmdFeed(context, parsedMessage)
-        type === Errors.ReturnType.Ok
-          ? reactDone(context, parsedMessage.context, kbMessage.id)
-          : reactFail(context, parsedMessage.context, kbMessage.id)
+        type !== Errors.ReturnType.Ok &&
+          reactFail(context, parsedMessage.context, kbMessage.id)
         return
       }
       case Message.BotMessageType.Debug: {
@@ -124,6 +114,12 @@ const onMessage = async (
         type === Errors.ReturnType.Ok
           ? reactDone(context, parsedMessage.context, kbMessage.id)
           : reactFail(context, parsedMessage.context, kbMessage.id)
+        return
+      }
+      case Message.BotMessageType.Show: {
+        const {type} = await CmdShow(context, parsedMessage)
+        type !== Errors.ReturnType.Ok &&
+          reactFail(context, parsedMessage.context, kbMessage.id)
         return
       }
       default:
@@ -197,6 +193,16 @@ const commands = [
       '!jira subscribe design\n' +
       '!jira subscribe frontend with updates\n' +
       '!jira unsubscribe 123',
+  },
+  {
+    name: 'jira show',
+    description: `Show Jira issue(s). You can also unfurl Jira issues by at-mentioning me.`,
+    usage: `show <issue-key> [<issue-key> ...]`,
+    title: `Show Jira issue(s)`,
+    body:
+      'Examples:\n\n' +
+      '!jira show DESIGN-1234\n' +
+      '!jira show DESIGN-1234 DESIGN-5678',
   },
   {
     name: 'jira debug',

--- a/jirabot/src/cmd-show.ts
+++ b/jirabot/src/cmd-show.ts
@@ -1,0 +1,99 @@
+import {Issue as JiraIssue} from './jira'
+import {numToEmoji, statusToEmoji} from './emoji'
+import {ShowMessage} from './message'
+import {Context} from './context'
+import * as Errors from './errors'
+import * as Utils from './utils'
+
+const issueTypeToEmojiMaybe = (issueType: string) => {
+  switch (issueType) {
+    case 'Story':
+      return ':scroll:'
+    case 'Bug':
+      return ':bug:'
+    case 'Epic':
+      return ':six_pointed_star:'
+    case 'Task':
+      return ':ballot_box_with_check:'
+    case 'Subtask':
+    default:
+      return `[${issueType}]`
+  }
+}
+
+const formatIssue = (issueKeyFromUser: string, issue: JiraIssue) => {
+  console.log(JSON.stringify(issue, null, 2))
+
+  const title = `${issueTypeToEmojiMaybe(issue.issueType)} *${issue.key}*${
+    issueKeyFromUser.toLowerCase() === issue.key.toLowerCase()
+      ? ''
+      : ` (${issueKeyFromUser})`
+  } | ${issue.status} ${issue.url}`
+  const summary = `*${issue.summary}*`
+  const metadata = `Reported by _${issue.reporterJira}_ ${
+    issue.createdTimeHumanized
+  }. ${
+    issue.assigneeJira
+      ? `Assigned to _${issue.assigneeJira}_.`
+      : 'Not assigned.'
+  }`
+
+  return [title, summary, metadata].join('\n')
+}
+
+export default async (
+  context: Context,
+  parsedMessage: ShowMessage
+): Promise<Errors.ResultOrError<undefined, undefined>> => {
+  const jiraRet = await context.getJiraFromTeamnameAndUsername(
+    context,
+    parsedMessage.context.teamName,
+    parsedMessage.context.senderUsername
+  )
+  if (jiraRet.type === Errors.ReturnType.Error) {
+    Errors.reportErrorAndReplyChat(
+      context,
+      parsedMessage.context,
+      jiraRet.error
+    )
+    return Errors.makeError(undefined)
+  }
+  const jira = jiraRet.result
+
+  try {
+    const issues = await Promise.all(
+      parsedMessage.issueKeys.map(issueKey =>
+        jira
+          .get({
+            issueKey,
+          })
+          .then((issue: JiraIssue) => ({issue, issueKey}))
+          .catch(error => ({error, issueKey}))
+      )
+    )
+
+    issues.forEach(({error, issue, issueKey}) =>
+      issue
+        ? Utils.replyToMessageContext(
+            context,
+            parsedMessage.context,
+            formatIssue(issueKey, issue),
+            issues.length === 1
+          )
+        : Utils.replyToMessageContext(
+            context,
+            parsedMessage.context,
+            `:warning: Failed to get issue: ${issueKey}`,
+            issues.length === 1
+          )
+    )
+    return Errors.makeResult(undefined)
+  } catch (err) {
+    Errors.reportErrorAndReplyChat(
+      context,
+      parsedMessage.context,
+      Errors.makeUnknownError(err).error
+    )
+    return Errors.makeError(undefined)
+  }
+}

--- a/jirabot/src/cmd-show.ts
+++ b/jirabot/src/cmd-show.ts
@@ -67,8 +67,8 @@ export default async (
           .get({
             issueKey,
           })
-          .then((issue: JiraIssue) => ({issue, issueKey}))
-          .catch(error => ({error, issueKey}))
+          .then((issue: JiraIssue) => ({error: undefined, issue, issueKey}))
+          .catch(error => ({error, issue: undefined, issueKey}))
       )
     )
 

--- a/jirabot/src/jira.ts
+++ b/jirabot/src/jira.ts
@@ -1,5 +1,4 @@
 import JiraClient from 'jira-connector'
-import {Issue as JiraIssue} from 'jira-connector/api/issue'
 import {BotConfig} from './bot-config'
 import * as Configs from './configs'
 import logger from './logger'
@@ -7,6 +6,9 @@ import * as Errors from './errors'
 import {Context} from './context'
 import mem from 'mem'
 import moment from 'moment'
+
+type JiraIssue = any
+// import {Issue as JiraIssue} from 'jira-connector/api/issue'
 
 export const looksLikeIssueKey = (str: string) =>
   !!str.match(/[A-Za-z0-9]+-[0-9]+/)

--- a/jirabot/src/jira.ts
+++ b/jirabot/src/jira.ts
@@ -6,14 +6,24 @@ import logger from './logger'
 import * as Errors from './errors'
 import {Context} from './context'
 import mem from 'mem'
+import moment from 'moment'
 
-const looksLikeIssueKey = (str: string) => !!str.match(/[A-Za-z]+-[0-9]+/)
+export const looksLikeIssueKey = (str: string) =>
+  !!str.match(/[A-Za-z0-9]+-[0-9]+/)
+
+export const findIssueKeys = (str: string) =>
+  str.match(/([A-Za-z0-9]+-[0-9]+)/g) || []
 
 export type Issue = {
   key: string
   summary: string
   status: string
   url: string
+  issueType: string
+  assigneeJira: string
+  reporterJira: string
+  project: string
+  createdTimeHumanized: string
 }
 
 export enum JiraSubscriptionEvents {
@@ -40,11 +50,20 @@ export class JiraClientWrapper {
   }
 
   jiraRespMapper = (issue: JiraIssue): Issue => ({
+    assigneeJira: issue.fields.assignee?.displayName,
+    createdTimeHumanized: moment(issue.fields.created).fromNow(),
+    issueType: issue.fields.issuetype.name,
     key: issue.key,
-    summary: issue.fields.summary,
+    project: issue.fields.project.name,
+    reporterJira: issue.fields.reporter?.displayName,
     status: issue.fields.status.statusCategory.name,
+    summary: issue.fields.summary,
     url: `https://${this.jiraHost}/browse/${issue.key}`,
   })
+
+  get({issueKey}: {issueKey: string}): Promise<any> {
+    return this.jiraClient.issue.getIssue({issueKey}).then(this.jiraRespMapper)
+  }
 
   getOrSearch({
     query,

--- a/jirabot/src/message.ts
+++ b/jirabot/src/message.ts
@@ -16,6 +16,7 @@ export enum BotMessageType {
   Auth = 'auth',
   Feed = 'feed',
   Debug = 'debug',
+  Show = 'show',
 }
 
 export type MessageContext = Readonly<{
@@ -137,6 +138,12 @@ export type DebugPprofMessage = Readonly<{
 }>
 export type DebugMessage = DebugLogSendMessage | DebugPprofMessage
 
+export type ShowMessage = Readonly<{
+  context: MessageContext
+  type: BotMessageType.Show
+  issueKeys: Array<string>
+}>
+
 export type Message =
   | UnknownMessage
   | SearchMessage
@@ -147,6 +154,7 @@ export type Message =
   | AuthMessage
   | FeedMessage
   | DebugMessage
+  | ShowMessage
 
 const getTextMessage = (message: ChatTypes.MsgSummary): string | undefined => {
   if (!message || !message.content) {
@@ -371,6 +379,16 @@ export const parseMessage = async (
   }
 
   if (!textBody.startsWith('!jira')) {
+    if (textBody.includes(`@${context.botConfig.keybase.username}`)) {
+      const issueKeys = Jira.findIssueKeys(textBody)
+      if (issueKeys.length) {
+        return {
+          context: messageContext,
+          type: BotMessageType.Show,
+          issueKeys,
+        }
+      }
+    }
     return undefined
   }
 
@@ -709,6 +727,34 @@ export const parseMessage = async (
             type: BotMessageType.Unknown,
             error: `unknown debug command ${fields[2]}`,
           }
+      }
+    }
+    case 'show': {
+      const inputKeys = fields.slice(2)
+      if (!inputKeys.length) {
+        if (!issueKeys.length) {
+          return {
+            context: messageContext,
+            type: BotMessageType.Unknown,
+            error: `at least one Jira issue key is required`,
+          }
+        }
+      }
+      const issueKeys = inputKeys.filter(Jira.looksLikeIssueKey)
+      if (!issueKeys.length) {
+        return {
+          context: messageContext,
+          type: BotMessageType.Unknown,
+          error:
+            inputKeys.length === 1
+              ? `${inputKeys[0]} is not a Jira issue key`
+              : `no valid Jira issue key is found`,
+        }
+      }
+      return {
+        context: messageContext,
+        type: BotMessageType.Show,
+        issueKeys,
       }
     }
     default: {

--- a/jirabot/src/message.ts
+++ b/jirabot/src/message.ts
@@ -5,7 +5,8 @@ import * as Errors from './errors'
 import logger from './logger'
 import * as Configs from './configs'
 import * as Jira from './jira'
-import isValidDomain from 'is-valid-domain'
+// No types
+const isValidDomain = require('is-valid-domain')
 
 export enum BotMessageType {
   Unknown = 'unknown',
@@ -740,7 +741,7 @@ export const parseMessage = async (
     case 'show': {
       const inputKeys = fields.slice(2)
       if (!inputKeys.length) {
-        if (!issueKeys.length) {
+        if (!inputKeys.length) {
           return {
             context: messageContext,
             type: BotMessageType.Unknown,

--- a/jirabot/src/message.ts
+++ b/jirabot/src/message.ts
@@ -5,6 +5,7 @@ import * as Errors from './errors'
 import logger from './logger'
 import * as Configs from './configs'
 import * as Jira from './jira'
+import isValidDomain from 'is-valid-domain'
 
 export enum BotMessageType {
   Unknown = 'unknown',
@@ -559,6 +560,13 @@ export const parseMessage = async (
               context: messageContext,
               type: BotMessageType.Unknown,
               error: `unknown team config parameter ${toSetName}`,
+            }
+          }
+          if (!isValidDomain(toSetValue)) {
+            return {
+              context: messageContext,
+              type: BotMessageType.Unknown,
+              error: `${toSetValue} is not a valid domain`,
             }
           }
           return {

--- a/jirabot/src/utils.ts
+++ b/jirabot/src/utils.ts
@@ -74,16 +74,19 @@ export const humanReadableArray = (list: Array<string>): string =>
 export const replyToMessageContext = (
   context: Context,
   messageContext: MessageContext,
-  body: string
+  body: string,
+  noQuote?: boolean
 ): Promise<any> =>
   context.bot.chat.send(
     messageContext.conversationId,
     {
       body,
     },
-    {
-      replyTo: messageContext.messageID,
-    }
+    noQuote
+      ? {
+          replyTo: messageContext.messageID,
+        }
+      : undefined
   )
 
 export const getJiraAccountID = async (

--- a/jirabot/yarn.lock
+++ b/jirabot/yarn.lock
@@ -3018,6 +3018,11 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+is-valid-domain@^0.0.14:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/is-valid-domain/-/is-valid-domain-0.0.14.tgz#26f918ed6be2f8554db281efb9f7169d840a6664"
+  integrity sha512-MTUz/3y25zTtutAfwrLyFK+1l2IL4bcq2iHVdYHIPQbvBJLunlYu9dsQdtLwD9HKPDyxCDlKnSbGcRwvjVeCxA==
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"

--- a/jirabot/yarn.lock
+++ b/jirabot/yarn.lock
@@ -3564,10 +3564,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-keybase-bot@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/keybase-bot/-/keybase-bot-3.4.0.tgz#9950c667a43e2691785efd9144f4bf0410f856d9"
-  integrity sha512-fcco6u4UH22t2Y2qvVc6uYnrLd9Yazw88GhP/ej9AOR8fWaFRd5YLz9lPeCLDab0inBNpNYIETCdE2oU1hB8Cg==
+keybase-bot@3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/keybase-bot/-/keybase-bot-3.6.1.tgz#d0262ed8359026926da00b69b43c53104fcfd0bf"
+  integrity sha512-AUI/CXHC8EgBX9Gf/h0rcRF6WB97nYWH/KCYyitwh3MmXLltr34DzDLp8jPeRF92k6vCrZ5mIhC2ecXW3dtprg==
   dependencies:
     isexe "2.0.0"
     lodash.camelcase "4.3.0"
@@ -3913,6 +3913,11 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
* add a show cmd
* unfurl ticket if at-mentioned
* don't react with :eyes: in most scenarios
* better error message for invalid `jiraHost` (resolves #222)