### PR TITLE
fix !jira search

### DIFF
--- a/jirabot/src/jira.ts
+++ b/jirabot/src/jira.ts
@@ -93,7 +93,7 @@ export class JiraClientWrapper {
         : new Promise(r => r()),
       this.jiraClient.search.search({
         jql,
-        fields: ['key', 'summary', 'status'],
+        fields: ['key', 'summary', 'status', 'project', 'issuetype'],
         method: 'GET',
         maxResults: 11,
       }),


### PR DESCRIPTION
We updated `jiraRespMapper` to add more fields for `!jira show`, but forgot to update the search call to request them. That caused `jiraRespMapper` to throw on response from `!jira search`.