### PR TITLE
Fix macrobot advertisements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/keybase/go-codec v0.0.0-20180928230036-164397562123
-	github.com/keybase/go-keybase-chat-bot v0.0.0-20200423194411-1bd071efaff7
+	github.com/keybase/go-keybase-chat-bot v0.0.0-20200424150524-0f0e2ab404cb
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mailru/easyjson v0.7.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/keybase/go-codec v0.0.0-20180928230036-164397562123 h1:yg56lYPqh9suJepqxOMd/liFgU/x+maRPiB30JNYykM=
 github.com/keybase/go-codec v0.0.0-20180928230036-164397562123/go.mod h1:r/eVVWCngg6TsFV/3HuS9sWhDkAzGG8mXhiuYA+Z/20=
-github.com/keybase/go-keybase-chat-bot v0.0.0-20200423194411-1bd071efaff7 h1:NdeMbP4c440iQDA8sS2TRCloJqpmKIzwHmAais6Na3o=
-github.com/keybase/go-keybase-chat-bot v0.0.0-20200423194411-1bd071efaff7/go.mod h1:vNc28YFzigVJod0j5EbuTtRIe7swx8vodh2yA4jZ2s8=
+github.com/keybase/go-keybase-chat-bot v0.0.0-20200424150524-0f0e2ab404cb h1:iq3W60YvIGdyTeRvFakE9S+JnThb6H9zlt72rjj/oH0=
+github.com/keybase/go-keybase-chat-bot v0.0.0-20200424150524-0f0e2ab404cb/go.mod h1:vNc28YFzigVJod0j5EbuTtRIe7swx8vodh2yA4jZ2s8=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/macrobot/macrobot/utils.go
+++ b/macrobot/macrobot/utils.go
@@ -1,0 +1,63 @@
+package macrobot
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/keybase/go-keybase-chat-bot/kbchat/types/chat1"
+)
+
+const (
+	back          = "`"
+	backs         = "```"
+	CreateCmdHelp = `You must specify a name for the macro, such as 'docs' or 'lunchflip' as well as a message for the bot to send whenever you invoke the macro.
+
+Examples:%s
+!macro create docs 'You can find documentation at: https://keybase.io/docs'
+!macro create lunchflip '/flip alice, bob, charlie'%s
+You can run the above macros using %s!docs%s or %s!lunchflip%s`
+)
+
+func getCreateForChannelCmd() chat1.UserBotCommandInput {
+	createForChannelDesc := fmt.Sprintf("Create a new macro for the current channel. %s",
+		fmt.Sprintf(CreateCmdHelp, backs, backs, back, back, back, back))
+	return chat1.UserBotCommandInput{
+		Name:        "macro create-for-channel",
+		Description: "Create a new macro for the current channel",
+		ExtendedDescription: &chat1.UserBotExtendedDescription{
+			Title:       `*!macro create-for-channel* <name> <message>`,
+			DesktopBody: createForChannelDesc,
+			MobileBody:  createForChannelDesc,
+		},
+	}
+}
+
+func getChannelType(channel chat1.ChatChannel, isConv bool) string {
+	if channel.MembersType == "team" {
+		if isConv {
+			return "channel"
+		}
+		return "team"
+	} else {
+		return "conversation"
+	}
+}
+
+func sanitizeMessage(message string) string {
+	if strings.HasPrefix(message, "/") && !isWhiteListed(message) {
+		// escape beginning slash
+		message = "\\" + message
+	}
+	// prevent stellar payments by escaping all '+'s
+	message = strings.ReplaceAll(message, "+", "\\+")
+	return message
+}
+
+func isWhiteListed(message string) bool {
+	for _, command := range whiteListedCommands {
+		if strings.HasPrefix(message, "/"+command) {
+			return true
+		}
+	}
+	return false
+}

--- a/macrobot/main.go
+++ b/macrobot/main.go
@@ -32,21 +32,13 @@ func NewBotServer(opts base.Options) *BotServer {
 }
 
 const (
-	back       = "`"
-	backs      = "```"
-	createHelp = `You must specify a name for the macro, such as 'docs' or 'lunchflip' as well as a message for the bot to send whenever you invoke the macro.
-
-Examples:%s
-!macro create docs 'You can find documentation at: https://keybase.io/docs'
-!macro create lunchflip '/flip alice, bob, charlie'%s
-You can run the above macros using %s!docs%s or %s!lunchflip%s`
+	back  = "`"
+	backs = "```"
 )
 
 func (s *BotServer) makeAdvertisement() kbchat.Advertisement {
 	createDesc := fmt.Sprintf("Create a new macro for the current team or conversation. %s",
-		fmt.Sprintf(createHelp, backs, backs, back, back, back, back))
-	createForChannelDesc := fmt.Sprintf("Create a new macro for the current channel. %s",
-		fmt.Sprintf(createHelp, backs, backs, back, back, back, back))
+		fmt.Sprintf(macrobot.CreateCmdHelp, backs, backs, back, back, back, back))
 	removeDesc := fmt.Sprintf(`Remove a macro from the current team or conversation. You must specify the name of the macro.
 
 Examples:%s
@@ -62,15 +54,6 @@ Examples:%s
 				Title:       `*!macro create* <name> <message>`,
 				DesktopBody: createDesc,
 				MobileBody:  createDesc,
-			},
-		},
-		{
-			Name:        "macro create-for-channel",
-			Description: "Create a new macro for the current channel",
-			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title:       `*!macro create-for-channel* <name> <message>`,
-				DesktopBody: createForChannelDesc,
-				MobileBody:  createForChannelDesc,
 			},
 		},
 		{


### PR DESCRIPTION
patch does the following:
- force non team advertisements to be to a specific `conv`
- only advertise `create-for-channel` command to teams
- 