### PR TITLE
crash on unhandled promise

### DIFF
--- a/jirabot/src/index.ts
+++ b/jirabot/src/index.ts
@@ -5,6 +5,10 @@ import startHTTPServer from './http-server'
 import startBackgroundTasks from './background-tasks'
 import logger from './logger'
 
+process.on('unhandledRejection', error => {
+  logger.fatal({msg: 'unhandled promise', error})
+})
+
 const botConfig = BotConfig.parse(process.env.JIRABOT_CONFIG || '')
 if (!botConfig) {
   logger.fatal('invalid bot-config')


### PR DESCRIPTION
I'm realizing the defunct bot usually stops at some warning about "unhandled promise". I incorrectly assumed it was something that we handled automatically but it turns out we don't. So instead, make the process crash on unhandled promise and rely on ECS to start a new task in that case. This should hopefully cover most failure cases.