### PR TITLE
add github release event

### DIFF
--- a/base/git/git.go
+++ b/base/git/git.go
@@ -130,3 +130,32 @@ func FormatPullRequestMsg(provider int, action string, username string, repo str
 
 	return res
 }
+
+/*
+Release Events
+
+GitHub: https://developer.github.com/v3/activity/events/types/#release
+Namespace: "published", "created", "edited", "deleted"
+
+GitLab: https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#release
+Namespace: "publish", "create", "edit", "delete"
+
+*/
+
+func FormatReleaseMsg(action, username, repo, version, name, releaseUrl, changes string) (res string) {
+	switch action {
+	case "publish", "published":
+		res = fmt.Sprintf("%s published the release %s (%s) on %s: \n%s\n", username, version, name, repo, changes)
+		res += releaseUrl
+	case "create", "created":
+		res = fmt.Sprintf("%s created the release %s (%s) on %s: \n%s\n", username, version, name, repo, changes)
+		res += releaseUrl
+	case "edit", "edited":
+		res = fmt.Sprintf("%s edited the release %s (%s) on %s: \n%s\n", username, version, name, repo, changes)
+		res += releaseUrl
+	case "delete", "deleted":
+		res = fmt.Sprintf("%s deleted the release %s (%s) on %s: \n%s\n", username, version, name, repo, changes)
+		res += releaseUrl
+	}
+	return res
+}

--- a/githubbot/README.md
+++ b/githubbot/README.md
@@ -23,6 +23,7 @@ The bot expects _read-only_ access to the Repository Permissions:
     - checks
     - contents
     - issues
+    - releases
     - pull requests
     - commit statuses
 ```
@@ -34,6 +35,7 @@ As well as the webhook events for:
     - pushes
     - statuses
     - issues
+    - releases
     - pull requests
 ```
 

--- a/githubbot/db.sql
+++ b/githubbot/db.sql
@@ -37,6 +37,7 @@ CREATE TABLE `features` (
   `pull_requests` boolean NOT NULL DEFAULT 1,
   `commits` boolean NOT NULL DEFAULT 0,
   `statuses` boolean NOT NULL DEFAULT 1,
+  `releases` boolean NOT NULL DEFAULT 1,
   UNIQUE KEY unique_subscription (`conv_id`, `repo`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/githubbot/githubbot/handler.go
+++ b/githubbot/githubbot/handler.go
@@ -141,7 +141,7 @@ func (h *Handler) handleSubscribe(cmd string, msg chat1.MsgSummary, create bool,
 			}
 		}
 		switch args[1] {
-		case "issues", "pulls", "statuses", "commits":
+		case "issues", "pulls", "statuses", "commits", "releases":
 			return h.handleSubscribeToFeature(repo, args[1], msg, create)
 		default:
 			return h.handleSubscribeToBranch(repo, args[1], msg, create)
@@ -302,7 +302,7 @@ func (h *Handler) handleSubscribeToFeature(repo, feature string, msg chat1.MsgSu
 	if currentFeatures == nil {
 		currentFeatures = &Features{}
 	}
-	// "issues", "pulls", "statuses", "commits"
+	// "issues", "pulls", "statuses", "commits", "releases"
 	switch feature {
 	case "issues":
 		currentFeatures.Issues = enable
@@ -312,6 +312,8 @@ func (h *Handler) handleSubscribeToFeature(repo, feature string, msg chat1.MsgSu
 		currentFeatures.Statuses = enable
 	case "commits":
 		currentFeatures.Commits = enable
+	case "releases":
+		currentFeatures.Releases = enable
 	default:
 		// Should never get here if check in handleSubscribe is correct
 		return fmt.Errorf("Error subscribing to feature: %s is not a valid feature", feature)

--- a/githubbot/githubbot/http.go
+++ b/githubbot/githubbot/http.go
@@ -150,6 +150,17 @@ func (h *HTTPSrv) formatMessage(convID chat1.ConvIDStr, event interface{}, repo 
 			event.GetIssue().GetTitle(),
 			event.GetIssue().GetHTMLURL(),
 		), ""
+	case *github.ReleaseEvent:
+		author := getPossibleKBUser(h.kbc, h.db, h.DebugOutput, event.GetSender().GetLogin(), convID)
+		return git.FormatReleaseMsg(
+			*event.Action,
+			author.String(),
+			event.GetRepo().GetName(),
+			event.GetRelease().GetTagName(),
+			event.GetRelease().GetName(),
+			event.GetRelease().GetURL(),
+			event.GetRelease().GetBody(),
+		), ""
 	case *github.PullRequestEvent:
 		var author username
 		if event.GetPullRequest().GetMerged() {

--- a/githubbot/githubbot/util.go
+++ b/githubbot/githubbot/util.go
@@ -216,6 +216,8 @@ func shouldParseEvent(event interface{}, features *Features) bool {
 		return features.PullRequests
 	case *github.PushEvent:
 		return features.Commits
+	case *github.ReleaseEvent:
+		return features.Releases
 	case *github.CheckRunEvent, *github.StatusEvent:
 		return features.Statuses
 	default:


### PR DESCRIPTION
### What does this MR does?

Add Github release event support

### Why we need it?

For we can track new release events from the GitHub repo.

### How to test?

- Install the bot
- subscribe to a new release
- wait the release events: `!github subscribe <REPO> releases`
