### PR TITLE
fix events length check

### DIFF
--- a/githubbot/githubbot/db.go
+++ b/githubbot/githubbot/db.go
@@ -196,7 +196,7 @@ func (f *Features) String() string {
 	}
 	if len(res) == 0 {
 		return "no events"
-	} else if len(res) == 4 {
+	} else if len(res) == 5 {
 		return "all events"
 	}
 	return strings.Join(res, ", ")


### PR DESCRIPTION
I believe this check should have been updated when the new `releases` event type was introduced on #263 