### PR TITLE
Add template support

### DIFF
--- a/webhookbot/db.sql
+++ b/webhookbot/db.sql
@@ -2,6 +2,8 @@ CREATE TABLE `hooks` (
   `id` varchar(100) NOT NULL,
   `name` varchar(100) NOT NULL,
   `conv_id` varchar(100) NOT NULL,
+  `template` varchar(10000) NOT NULL,
+  CONSTRAINT hook UNIQUE (`name`,`conv_id`),
   PRIMARY KEY (`id`),
   KEY `conv_id` (`conv_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/webhookbot/main.go
+++ b/webhookbot/main.go
@@ -48,7 +48,30 @@ func (s *BotServer) makeAdvertisement() kbchat.Advertisement {
 	createExtended := fmt.Sprintf(`Create a new webhook for sending messages into the current conversation. You must supply a name as well to identify the webhook. To use a webhook URL, supply a %smsg%s URL parameter, or a JSON POST body with a field %smsg%s.
 
 	Example:%s
-		!webhook create alerts%s`, back, back, back, back, backs, backs)
+		!webhook create alerts%s
+
+	Example (using custom template):%s
+		!webhook create alerts *{{.title}}*
+		%s{{.body}}%s%s
+
+	Templates:
+		Information about creating templates, and some examples can be found at %shttps://pkg.go.dev/text/template%s
+		You can test your templates against your JSON data at %shttps://play.golang.org/p/vC06kRCQDfX%s
+
+		There are 2 custom variables you can use in your templates (see the default template below for example usage):
+		  - %s$webhookName%s: The name you gave the webhook
+		  - %s$webhookMethod%s: Whether GET or POST was used when the webhook endpoint was fetched
+
+		If you don't provide a template, this is the default:%s
+		[hook: *{{$webhookName}}*]
+
+		{{if eq $webhookMethod "POST"}}{{.msg}}{{else}}{{index .msg 0}}{{end}}%s`,
+		back, back, back, back, backs, backs, backs, back, back, backs, back, back, back, back, back, back, back, back, backs, backs)
+	updateExtended := fmt.Sprintf(`Update an existing webhook's template. Leave the template field empty to use the default template. For more information about templates, see the help text for %s!webhook create%s.
+
+	Example:%s
+		!webhook update alerts *New Alert: {{.title}}*
+		%s{{.body}}%s%s`, back, back, backs, back, back, backs)
 	removeExtended := fmt.Sprintf(`Remove a webhook from the current conversation. You must supply the name of the webhook.
 
 	Example:%s
@@ -57,12 +80,24 @@ func (s *BotServer) makeAdvertisement() kbchat.Advertisement {
 	cmds := []chat1.UserBotCommandInput{
 		{
 			Name:        "webhook create",
+			Usage:       "<name> [<template>]",
 			Description: "Create a new webhook for sending into the current conversation",
 			ExtendedDescription: &chat1.UserBotExtendedDescription{
-				Title: `*!webhook create* <name>
+				Title: `*!webhook create* <name> [<template>]
 Create a webhook`,
 				DesktopBody: createExtended,
 				MobileBody:  createExtended,
+			},
+		},
+		{
+			Name:        "webhook update",
+			Usage:       "<name> [<template>]",
+			Description: "Update the template of an existing webhook in the current conversation",
+			ExtendedDescription: &chat1.UserBotExtendedDescription{
+				Title: `*!webhook update* <name> [<template>]
+Update a webhook's template`,
+				DesktopBody: updateExtended,
+				MobileBody:  updateExtended,
 			},
 		},
 		{


### PR DESCRIPTION
This PR adds support for webhooks to have templates. The default template will look and act exactly like the bot's current non-template functionality.

This PR does not currently include any migrations, which will be needed to add the new template column before this gets deployed to an existing instance.

I've also fixed a bug that allowed someone to create multiple webhooks with the same name in a channel. Because of this, we may also need an additional migration that finds any channels with multiple webhooks with the same name, and rename them.

/cc @joshblum @mmaxim 